### PR TITLE
[B2BP-322] - Removed RADD information from SEND legacy

### DIFF
--- a/api/data/faq-it.tsx
+++ b/api/data/faq-it.tsx
@@ -48,10 +48,8 @@ export const itFaqData: IFaqData = {
           id: "notifiche-composizione",
           title: "Da cosa è composta una notifica?",
           description: [
-            `Fino ad ora ogni notifica era composta da uno o più “atti”, cioè i documenti notificati, 
-            e da eventuali altri documenti. Per esempio, una multa poteva essere composta da un verbale di contravvenzione 
-            (il documento notificato), da una fotografia dell’autovelox e da un bollettino per il pagamento (gli altri documenti).`,
-            `Con SEND invece, la notifica si concretizza in un avviso (tecnicamente Avviso di Avvenuta Ricezione) che include le istruzioni per ottenere i documenti notificati e gli eventuali altri documenti.`,
+            `Ogni notifica è composta da uno o più “atti”, cioè i documenti notificati, e da eventuali altri documenti. Per esempio, una multa può essere composta da un verbale di contravvenzione (il documento notificato), da una fotografia dell'autovelox e da un bollettino per il pagamento (gli altri documenti).`,
+            `Una notifica inviata per via digitale con SEND si concretizza in un avviso con le istruzioni per visualizzare online i documenti. Una notifica inviata tramite raccomandata cartacea, invece, contiene sia l'avviso che i documenti.`,
           ],
         },
       ],
@@ -175,96 +173,21 @@ export const itFaqData: IFaqData = {
           id: "recapiti-se-non-inserisco",
           title:
             "Cosa succede se non inserisco nessun recapito digitale o se non posso accedere a SEND?",
-          description: (
-            <Box>
-              <Typography variant="body2" component="span" sx={{ mr: "4px" }}>
-                Se nei registri pubblici (INAD, INIPEC o registri di un ente) c’è una PEC riconducibile a te, riceverai l’avviso di avvenuta ricezione a quell’indirizzo di posta elettronica certificata.
-                Se non c’è, riceverai l’avviso di avvenuta ricezione tramite raccomandata cartacea. In entrambi i casi, dovrai
-              </Typography>
-              <Typography variant="body2" component="span">
-                <a href={PN_PF_URL}>accedere a SEND</a>
-              </Typography>
-              <Typography variant="body2" component="span" sx={{ mr: "4px" }}>
-                {" "}o andare in qualsiasi Ufficio Postale per ottenere i documenti notificati e gli eventuali altri documenti.
-              </Typography>
-            </Box>
-          ),
+          description: [
+            `Se nei registri pubblici c'è una PEC riconducibile a te, riceverai l'avviso di avvenuta ricezione a quell'indirizzo. Per ottenere i documenti notificati, dovrai accedere a SEND.`,
+            `Se nei registri pubblici non c'è una PEC riconducibile a te, riceverai la notifica, comprensiva dei documenti, tramite raccomandata cartacea.`,
+          ],
         },
         {
           id: "recapiti-differenza-tra-tipi",
           title: `Che differenza c'è tra PEC, app IO, e-mail, numero di cellulare e raccomandata cartacea?`,
-          description: (
-            <Box>
-
-              <FaqTextSection
-                ariaLabel="Se nella sezione “I tuoi recapiti” di SEND o in uno dei registri pubblici 
-                c’è una PEC a te riconducibile, riceverai l’avviso di avvenuta ricezione a quell’indirizzo. 
-                Per visualizzare i documenti notificati e pagare eventuali spese, dovrai"
-              >
-                Se nella sezione “I tuoi recapiti” di SEND o in uno dei registri pubblici (INAD, INIPEC o registri di un ente) c’è una PEC a te riconducibile, riceverai l’avviso di avvenuta ricezione a quell’indirizzo di posta elettronica certificata.
-                Per visualizzare i documenti notificati e pagare eventuali spese, dovrai
-              </FaqTextSection>
-              <FaqLink href={PN_PF_URL} noSpaceAfter>
-                accedere a SEND
-              </FaqLink>
-              <FaqTextSection
-                ariaLabel={` con SPID o CIE.`}
-              >
-                {` con SPID o CIE.`}
-              </FaqTextSection>
-
-              <br /><br />
-
-              <FaqParagraph
-                ariaLabel="Se hai attivato il servizio “Notifiche digitali” di IO, quando c’è una notifica per te riceverai un messaggio in app. 
-                Potrai visualizzare i documenti notificati e pagare eventuali spese direttamente in IO, senza dover accedere a SEND con SPID o CIE. "
-              >
-                Se hai attivato il servizio “Notifiche digitali” di IO, quando c’è una notifica per te riceverai un messaggio in app.
-                Potrai visualizzare i documenti notificati e pagare eventuali spese direttamente in IO, senza dover accedere a SEND con SPID o CIE.
-              </FaqParagraph>
-
-              <FaqTextSection
-                ariaLabel="Se hai inserito un’e-mail o un numero di cellulare, quando c’è una notifica per te riceverai un messaggio su questi canali. 
-                Per visualizzare i documenti notificati e pagare eventuali spese, dovrai"
-              >
-                Se hai inserito un’e-mail o un numero di cellulare, quando c’è una notifica per te riceverai un messaggio su questi canali.
-                Per visualizzare i documenti notificati e pagare eventuali spese, dovrai
-              </FaqTextSection>
-              <FaqLink href={PN_PF_URL} noSpaceAfter>
-                accedere a SEND
-              </FaqLink>
-              <FaqTextSection
-                ariaLabel={`con SPID o CIE.`}
-              >
-                {` con SPID o CIE.`}
-              </FaqTextSection>
-
-              <br /><br />
-
-              <FaqTextSection
-                ariaLabel="Se vuoi inserire o modificare i recapiti,"
-              >
-                Se vuoi inserire o modificare i recapiti,
-              </FaqTextSection>
-              <FaqLink href={PN_PF_URL} noSpaceAfter>
-                accedi a SEND
-              </FaqLink>
-              <FaqTextSection
-                ariaLabel={` e vai alla sezione “I tuoi recapiti”. `}
-              >
-                {` e vai alla sezione “I tuoi recapiti”. `}
-              </FaqTextSection>
-
-              <br /><br />
-
-              <FaqTextSection
-                ariaLabel="Se non hai inserito nessun recapito digitale (PEC, app IO, e-mail o numero di cellulare), se l’invio al tuo recapito non va a buon fine o se non leggi la notifica online o da app IO entro i tempi stabiliti, riceverai a casa una raccomandata contentente un avviso di avvenuta ricezione che contiene le informazioni essenziali della notifica e ha di per sé valore legale. Per ottenere i documenti notificati, dovrai comunque accedere a SEND con SPID o CIE oppure recarti in qualsiasi Ufficio Postale e chiedere di usufruire del servizio “Stampa notifica”."
-              >
-                Se non hai inserito nessun recapito digitale (PEC, app IO, e-mail o numero di cellulare), se l’invio al tuo recapito non va a buon fine o se non leggi la notifica online o da app IO entro i tempi stabiliti, riceverai a casa una raccomandata contentente un avviso di avvenuta ricezione che contiene le informazioni essenziali della notifica e ha di per sé valore legale. Per ottenere i documenti notificati, dovrai comunque accedere a SEND con SPID o CIE oppure recarti in qualsiasi Ufficio Postale e chiedere di usufruire del servizio “Stampa notifica”.
-              </FaqTextSection>
-
-            </Box>
-          ),
+          description: [
+            `Se nella sezione "I tuoi recapiti" di SEND o in uno dei registri pubblici c'è una PEC a te riconducibile, riceverai l'avviso di avvenuta ricezione a quell'indirizzo. Per visualizzare i documenti notificati e pagare eventuali spese, dovrai accedere a SEND con SPID o CIE, seguendo le indicazioni riportate nell'avviso.`,
+            `Se hai attivato il servizio "Notifiche digitali" di IO, quando c'è una notifica per te riceverai un messaggio in app. Potrai visualizzare i documenti notificati e pagare eventuali spese direttamente in IO, senza dover accedere a SEND con SPID o CIE.`,
+            `Se hai inserito un'e-mail o un numero di cellulare, quando c'è una notifica per te riceverai un messaggio su questi canali. Per visualizzare i documenti notificati e pagare eventuali spese, dovrai accedere a SEND con SPID o CIE seguendo le indicazioni.`,
+            `Se vuoi inserire o modificare i recapiti, accedi a SEND e vai alla sezione "I tuoi recapiti".`,
+            `Se non hai inserito nessun recapito digitale riceverai la notifica, comprensiva dei documenti, tramite raccomandata cartacea.`,
+          ],
         },
         {
           id: "recapiti-pec-recapito-principale",
@@ -293,13 +216,9 @@ export const itFaqData: IFaqData = {
             <Box>
               <FaqParagraph
                 flat
-                ariaLabel={`È il documento che ricevi quando la notifica ti viene inviata tramite PEC o raccomandata cartacea. 
-                L’invio di questo documento ha di per sé valore legale perché contiene 
-                le informazioni essenziali della notifica, ossia:`}
+                ariaLabel={`È il documento che ricevi via PEC o tramite raccomandata quando c’è una notifica per te. L'invio di questo documento ha di per sé valore legale perché contiene le informazioni essenziali della notifica, ossia:`}
               >
-                {`È il documento che ricevi quando la notifica ti viene inviata tramite PEC o raccomandata cartacea. 
-                L’invio di questo documento ha di per sé valore legale perché contiene 
-                le informazioni essenziali della notifica, ossia:`}
+                {`È il documento che ricevi via PEC o tramite raccomandata quando c’è una notifica per te. L'invio di questo documento ha di per sé valore legale perché contiene le informazioni essenziali della notifica, ossia:`}
               </FaqParagraph>
               <ul style={{ marginTop: 0 }}>
                 <li>
@@ -445,10 +364,7 @@ export const itFaqData: IFaqData = {
                 <a href={PERFEZIONAMENTO_PATH}>data di perfezionamento</a>
               </Typography>
               <Typography variant="body2" component="span" sx={{ mr: "4px" }}>
-                {`. 
-              Oltre quel termine, non potrai più né visualizzarli dall’app IO o da SEND, né richiederne la stampa presso un Ufficio Postale. 
-              Dovrai contattare l’ente che te li ha inviati.
-              `}
+                {`. Oltre quel termine, non potrai più visualizzarli né dall’app IO né da SEND. Dovrai contattare l’ente che te li ha inviati. L’avviso di avvenuta ricezione, invece, resta disponibile per 10 anni dalla data di perfezionamento.`}
               </Typography>
             </Box>
           ),
@@ -472,14 +388,6 @@ export const itFaqData: IFaqData = {
             Nel caso di notifiche con più avvisi di pagamento il costo per l’invio sarà incluso soltanto in uno, 
             e non in tutti.`,
             `Per esempio, ci sono dei casi in cui si può decidere se pagare la notifica in un’unica soluzione o a rate. Se si sceglie di pagare in un’unica soluzione, il costo per l’invio sarà incluso nel relativo avviso di pagamento. Se si sceglie di pagare a rate il costo di invio sarà incluso in uno solo dei vari avvisi, generalmente in quello relativo alla prima rata.`,
-          ],
-        },
-        {
-          id: "ricezione-raccomandata-cartacea",
-          title: `Ho ricevuto un avviso di avvenuta ricezione tramite raccomandata cartacea. Cosa devo fare?`,
-          description: [
-            `L’avviso di avvenuta ricezione contiene le informazioni essenziali della notifica e ha valore legale. Per questo, devi seguire le indicazioni riportate nell’avviso per i ottenere e leggere il prima possibile i documenti notificati e gli eventuali altri documenti. Hai due modi per farlo: gratis, inquadrando il codice QR o digitando nella barra di ricerca del tuo browser l’URL che trovi nell’avviso di avvenuta ricezione; oppure a pagamento, in qualsiasi Ufficio Postale.`,
-            `Se li ritiri in Ufficio Postale, porta con te l’avviso di avvenuta ricezione, un tuo documento di riconoscimento e il tuo Codice Fiscale. Se hai ricevuto la notifica in qualità di persona giuridica, dovrai mostrare anche un documento che attesti il tuo ruolo di legale rappresentante. Una volta ottenuti i documenti, leggili e paga eventuali spese.`,
           ],
         },
       ],

--- a/api/data/it/PF.tsx
+++ b/api/data/it/PF.tsx
@@ -62,9 +62,13 @@ const infoblock1_1 = `Le notifiche sono comunicazioni a valore legale emesse in 
 
 const infoblock1_2 = `Puoi anche pagare eventuali costi grazie all'integrazione con pagoPA, visualizzare lo storico delle notifiche ricevute e gestirle direttamente online. Inoltre, ti basta accettare una delega per accedere anche alle notifiche dei tuoi familiari.`;
 
-const infoblock2 = `Per inviarti le comunicazioni a valore legale, SEND dà la priorità ai tuoi recapiti digitali. In ogni momento, puoi accedere online al Servizio Notifiche Digitali con SPID o CIE per indicare o aggiornare il tuo domicilio digitale di piattaforma oppure i tuoi recapiti per ricevere un messaggio di cortesia, quando un ente ti invia una notifica: app IO, email e/o numero di cellulare.`;
+const infoblock2 = `Per inviarti le comunicazioni a valore legale, SEND dà la priorità ai tuoi recapiti digitali. In ogni momento, puoi accedere online al Servizio Notifiche Digitali con SPID e CIE per indicare o aggiornare o il tuo recapito legale (PEC) oppure i tuo recapiti di cortesia (app IO, email e/o numero di cellulare).`;
 
-const infoblock2_1 = `Se non hai indicato nessuno di questi recapiti digitali, non risulta a te associata una PEC e non accedi alla notifica su SEND entro i tempi indicati, riceverai tramite raccomandata cartacea un Avviso di Avvenuta Ricezione con le indicazioni per visualizzare online gli atti notificati o ritirarli presso un qualsiasi ufficio postale.`;
+const infoblock2_1 = `Se non indichi alcun recapito o non accedi alla notifica attraverso SEND da canali diversi dalla PEC `;
+
+const infoblock2_2 = `entro i tempi indicati`;
+
+const infoblock2_3 = `, continuerai a ricevere le notifiche tramite raccomandata cartacea.`;
 
 const infoblock3_2 = `Le Pubbliche Amministrazioni stanno gradualmente adottando il nuovo Servizio Notifiche Digitali, per questo è possibile che non tutti gli atti ti saranno già notificati con questa modalità.`;
 
@@ -120,8 +124,19 @@ export const pfInfoBlocks: Array<IInfoblockData> = [
           <Typography variant="body2" tabIndex={0} aria-label={infoblock2}>
             {infoblock2}
           </Typography>
+
           <Typography variant="body2" tabIndex={0} aria-label={infoblock2_1}>
             {infoblock2_1}
+            <Link
+              href="/perfezionamento"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={infoblock2_2}
+              sx={{ fontWeight: "bold", color: "primary.main" }}
+            >
+              {infoblock2_2}
+            </Link>
+            {infoblock2_3}
           </Typography>
         </>
       ),
@@ -356,20 +371,18 @@ export const pfShowcases: Array<IShowcaseData> = [
 /* ************************************** */
 
 /** Walkthrough mocked data */
-const walkthrough1 = `Per ogni notifica, SEND verifica che ci sia una PEC a te associata o da te indicata per l'invio dell'avviso di avvenuta ricezione. Invia anche un avviso di cortesia agli altri tuoi recapiti digitali (app IO, e-mail e numero di cellulare), se li hai inseriti. Se non hai indicato alcun recapito digitale e non accedi online alla notifica attraverso SEND, riceverai l’Avviso di Avvenuta Ricezione tramite raccomandata cartacea.`;
+const walkthrough1 = `Per ogni notifica, SEND verifica che ci sia una PEC a te associata o da te indicata per l'invio dell'avviso di avvenuta ricezione. Invia anche un avviso di cortesia agli altri tuoi recapiti digitali (app IO, e-mail e numero di cellulare), se li hai inseriti. Se non hai indicato alcun recapito digitale e non accedi online alla notifica attraverso SEND, riceverai una raccomandata cartacea.`;
 
-const walkthrough2 = `Dall'avviso ricevuto, puoi accedere online a SEND per leggere la notifica e scaricare i relativi documenti allegati. Se attivi il servizio su IO, puoi visualizzare il contenuto direttamente in app: questo equivale alla firma della ricevuta di ritorno di una raccomandata tradizionale e al `;
+const walkthrough2 = `Dal messaggio ricevuto, puoi accedere online alla piattaforma per leggere la notifica e scaricare i relativi documenti allegati. Se attivi il servizio su IO, puoi visualizzare il contenuto direttamente in app: questo equivale alla firma della ricevuta di ritorno di una raccomandata tradizionale e al `;
 
-const walkthrough2_1 = `
- immediato della notifica. In alternativa, puoi ottenere i documenti notificati recandoti presso qualsiasi ufficio postale.
-`;
-const walkthrough2_2 = `perfezionamento`;
-const walkthrough3 = `
-Se c'è un importo da pagare, grazie all'integrazione con pagoPA, puoi procedere contestualmente online da SEND 
-oppure direttamente da IO. Se preferisci recarti presso uno sportello, dovrai avere con te il modulo di pagamento 
-allegato alla notifica.
-`;
+const walkthrough2_1 = `perfezionamento`;
+
+const walkthrough2_2 = ` immediato della notifica.`;
+
+const walkthrough3 = `Se c'è un importo da pagare, grazie all'integrazione con pagoPA, puoi procedere contestualmente online da SEND oppure direttamente da IO. Se preferisci recarti presso uno sportello, dovrai avere con te il modulo di pagamento allegato alla notifica.`;
+
 const walkthrough4 = `Se lo desideri, puoi delegare altre persone, fisiche o giuridiche, a visualizzare le tue notifiche online. Per farlo, accedi a SEND con SPID o CIE e inserisci nella sezione Deleghe i dati della persona che vuoi delegare.`;
+
 export const pfWalkthrough: WalkthroughProps = {
   title: "Come funziona?",
   items: [
@@ -387,18 +400,18 @@ export const pfWalkthrough: WalkthroughProps = {
       title: "Leggi il contenuto",
       subtitle: (
         <Typography variant="body2" tabIndex={0} aria-label={walkthrough2}>
-            {walkthrough2}
-            <Link
-              href="/perfezionamento"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={walkthrough2_2}
-              sx={{ fontWeight: "bold", color: "primary.main" }}
-            >
-              {walkthrough2_2}
-            </Link>
+          {walkthrough2}
+          <Link
+            href="/perfezionamento"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={walkthrough2_1}
+            sx={{ fontWeight: "bold", color: "primary.main" }}
+          >
             {walkthrough2_1}
-          </Typography>
+          </Link>
+          {walkthrough2_2}
+        </Typography>
       ),
     },
     {

--- a/api/data/it/PF.tsx
+++ b/api/data/it/PF.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Container, Grid, Link, List, ListItem, Stack, Typography, useMediaQuery } from "@mui/material";
+import { Box, Container, Grid, Link, List, ListItem, Stack, Typography, useMediaQuery } from "@mui/material";
 import { useTheme } from '@mui/material/styles';
 import { HeroProps, WalkthroughProps } from "@pagopa/mui-italia";
 import { IMAGES_PATH, PN_PF_URL } from "@utils/constants";
@@ -62,7 +62,7 @@ const infoblock1_1 = `Le notifiche sono comunicazioni a valore legale emesse in 
 
 const infoblock1_2 = `Puoi anche pagare eventuali costi grazie all'integrazione con pagoPA, visualizzare lo storico delle notifiche ricevute e gestirle direttamente online. Inoltre, ti basta accettare una delega per accedere anche alle notifiche dei tuoi familiari.`;
 
-const infoblock2 = `Per inviarti le comunicazioni a valore legale, SEND dà la priorità ai tuoi recapiti digitali. In ogni momento, puoi accedere online al Servizio Notifiche Digitali con SPID e CIE per indicare o aggiornare o il tuo recapito legale (PEC) oppure i tuo recapiti di cortesia (app IO, email e/o numero di cellulare).`;
+const infoblock2 = `Per inviarti le comunicazioni a valore legale, SEND dà la priorità ai tuoi recapiti digitali. In ogni momento, puoi accedere online al Servizio Notifiche Digitali con SPID e CIE per indicare o aggiornare o il tuo recapito legale (PEC) oppure i tuoi recapiti di cortesia (app IO, email e/o numero di cellulare).`;
 
 const infoblock2_1 = `Se non indichi alcun recapito o non accedi alla notifica attraverso SEND da canali diversi dalla PEC `;
 
@@ -177,11 +177,9 @@ export const pfInfoBlocks: Array<IInfoblockData> = [
     data: {
       title: "PEC",
       content: (
-        <>
-          <Typography variant="body2" tabIndex={0} aria-label={infoblock4}>
+        <Typography variant="body2" tabIndex={0} aria-label={infoblock4}>
             {infoblock4}
           </Typography>
-        </>
       ),
       inverse: false,
       image: `${IMAGES_PATH}/pf-infoblock-5.png`,
@@ -196,11 +194,9 @@ export const pfInfoBlocks: Array<IInfoblockData> = [
     data: {
       title: "Email e SMS",
       content: (
-        <>
-          <Typography variant="body2" tabIndex={0} aria-label={infoblock5}>
+        <Typography variant="body2" tabIndex={0} aria-label={infoblock5}>
             {infoblock5}
           </Typography>
-        </>
       ),
       inverse: false,
       image: `${IMAGES_PATH}/pf-infoblock-7.png`,
@@ -343,11 +339,7 @@ export const pfShowcases: Array<IShowcaseData> = [
           ),
         },
         {
-          /**
-           * Waiting for IOIcon
-           */
-          // icon: <IOIcon />,
-          icon: <img src={`${IMAGES_PATH}/IOIcon.svg`} />,
+          icon: <img src={`${IMAGES_PATH}/IOIcon.svg`} alt="Icona di appIO"/>,
           title: "App IO",
           subtitle: (
             <Typography variant="body2" tabIndex={0} aria-label={showcase2_2}>

--- a/api/data/it/PH.tsx
+++ b/api/data/it/PH.tsx
@@ -96,7 +96,7 @@ const infoblock1_2 = `Gli enti non devono fare altro che depositare l’atto da 
 
 const infoblock2_1 = `I cittadini che lo desiderano possono ricevere e consultare le notifiche in digitale, accedendo a SEND tramite SPID o CIE o direttamente dall’app IO.`;
 
-const infoblock2_2 = `In ogni caso la piattaforma garantisce libertà di scelta: i destinatari possono sempre indicare come ricevere le comunicazioni secondo le proprie preferenze e avere accesso alle notifiche in qualsiasi momento, online o da punti fisici.`;
+const infoblock2_2 = `In ogni caso la piattaforma garantisce libertà di scelta: i destinatari possono sempre indicare come ricevere le comunicazioni secondo le proprie preferenze.`;
 
 const infoblock3_1 = `SEND mette a disposizione un unico spazio condiviso in cui diversi referenti di una stessa impresa possono visualizzare e gestire in modo totalmente digitale tutte le notifiche ricevute dai vari enti e pagare eventuali importi dovuti. `;
 

--- a/api/data/it/PI.tsx
+++ b/api/data/it/PI.tsx
@@ -207,7 +207,7 @@ export const piShowcases: Array<IShowcaseData> = [
 
 /** Walkthrough mocked data */
 const paWalkthrough1 =
-  "Per ogni notifica, SEND verifica che ci sia una PEC associata alla tua impresa, o da te indicata, per l'invio dell'avviso di avvenuta ricezione. Invia anche un avviso di cortesia agli altri tuoi recapiti digitali (e-mail e numero di cellulare), se inseriti. Se non hai indicato alcun recapito digitale, non c’è alcuna pec associata alla tua impresa e non accedi alla notifica attraverso SEND, riceverai un Avviso di Avvenuta Ricezione tramite raccomandata.";
+  "Per ogni notifica, SEND verifica che ci sia una PEC associata alla tua impresa per l'invio dell'avviso di avvenuta ricezione. Invia anche un avviso di cortesia agli altri tuoi recapiti digitali (e-mail e numero di cellulare), se li hai inseriti. Se non hai indicato alcun recapito digitale e non accedi online alla notifica attraverso SEND, riceverai una raccomandata cartacea.";
 const paWalkthrough2 =
   "Dal messaggio ricevuto, puoi accedere online alla piattaforma per leggere la notifica e scaricare i relativi atti notificati.";
 const paWalkthrough2_1 =

--- a/pages/cittadini/index.tsx
+++ b/pages/cittadini/index.tsx
@@ -27,7 +27,7 @@ const CittadiniPage: NextPage = () => (
       <Infoblock {...getInfoblockData(USER_TYPE, "infoblock 4")} />
       <div className="dark"><InfoblockCustomCittadini></InfoblockCustomCittadini></div>
       <Infoblock {...getInfoblockData(USER_TYPE, "infoblock 5")} />
-      <Infoblock {...getInfoblockData(USER_TYPE, "infoblock 6")} />
+      {/* <Infoblock {...getInfoblockData(USER_TYPE, "infoblock 6")} /> */}
       {/* <Showcase {...getShowcaseData(USER_TYPE, "showcase 2")} /> */}
       <Walkthrough {...getWalkthroughData(USER_TYPE)} />
       <div className="dark"><Infoblock {...getInfoblockData(USER_TYPE, "infoblock 3")} /></div>

--- a/pages/imprese/index.tsx
+++ b/pages/imprese/index.tsx
@@ -27,7 +27,7 @@ const ImpresePage: NextPage = () => (
       <Infoblock {...getInfoblockData(USER_TYPE, "infoblock 3")}></Infoblock> 
       <Showcase {...getShowcaseData(USER_TYPE, "showcase 1")} />
       <div className="light"><Walkthrough {...getWalkthroughData(USER_TYPE)} /></div> 
-      <CustomInfoblockImprese></CustomInfoblockImprese>
+      {/* <CustomInfoblockImprese></CustomInfoblockImprese> */}
     </main>
   </>
 );


### PR DESCRIPTION
Description
Removed RADD content

List of Changes
Changed the files "faq-it.tsx", "PH.tsx", "PF.tsx" and "PI.tsx". Changed the "index.tsx" in "cittadini" and "imprese" folders.

Motivation and Context
Remove RADD information from SEND legacy

How Has This Been Tested?
Execute on locally the SEND Site

Screenshots (if appropriate):

Types of changes
New feature (non-breaking change which adds functionality)

Checklist:
My change not requires a change to the documentation.