### PR TITLE
refactor/PN-12440 - Avoid showing untranslated labels during translations loading

### DIFF
--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -4,13 +4,13 @@ const Loading = () => {
   return (
     <Stack sx={{ background: 'white'}} position="absolute" zIndex={1000} height="100%" width="100%" direction="column">
       <Skeleton // Header
-        sx={{ height: '20%', mb: 3 }}
+        sx={{ height: '20%', mb: 1 }}
         width="100%"
         animation="wave"
         variant="rounded"
       />
       <Skeleton // Main
-        sx={{ height: '50%', mb: 3 }}
+        sx={{ height: '55%', mb: 1 }}
         width="100%"
         animation="wave"
         variant="rounded"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import Layout from "../components/Layout";
 
 import "../styles/default.css";
 import { LangProvider } from "../context/lang-context";
-import Loading from "./loading";
+import Loading from "../components/loading";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const noLayout = pageProps.noLayout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import Layout from "../components/Layout";
 
 import "../styles/default.css";
 import { LangProvider } from "../context/lang-context";
-import { Skeleton } from "@mui/material";
+import Loading from "./loading";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const noLayout = pageProps.noLayout;
@@ -17,11 +17,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ThemeProvider theme={theme}>
       <LangProvider lang={pageProps.lang} translations={pageProps.translations}>
         
-        {translationLoading && 
-        <Skeleton
-          sx={{ position: "absolute", backgroundColor: 'background.default', zIndex: 1000 }}
-          width="100%" height="100vh" animation="wave" variant="rounded"
-        />}
+        {translationLoading && <Loading />}
         
         {noLayout ? (
           // Se noLayout è true, renderizza solo il componente

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,21 +7,30 @@ import Layout from "../components/Layout";
 
 import "../styles/default.css";
 import { LangProvider } from "../context/lang-context";
+import { Skeleton } from "@mui/material";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const noLayout = pageProps.noLayout;
+  const translationLoading = !pageProps.lang && !pageProps.translations;
 
   return (
     <ThemeProvider theme={theme}>
       <LangProvider lang={pageProps.lang} translations={pageProps.translations}>
+        
+        {translationLoading && 
+        <Skeleton
+          sx={{ position: "absolute", backgroundColor: 'background.default', zIndex: 1000 }}
+          width="100%" height="100vh" animation="wave" variant="rounded"
+        />}
+        
         {noLayout ? (
           // Se noLayout è true, renderizza solo il componente
-          <Component {...pageProps} />
+            <Component {...pageProps} />
         ) : (
           // Altrimenti, avvolgilo nel LandingLayout
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
         )}
       </LangProvider>
     </ThemeProvider>

--- a/src/pages/loading.tsx
+++ b/src/pages/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton, Stack } from "@mui/material";
+
+const Loading = () => {
+  return (
+    <Stack sx={{ background: 'white'}} position="absolute" zIndex={1000} height="100%" width="100%" direction="column">
+      <Skeleton // Header
+        sx={{ height: '20%', mb: 3, backgroundColor: "background.default", zIndex: 1000 }}
+        width="100%"
+        animation="wave"
+        variant="rounded"
+      />
+      <Skeleton // Main
+        sx={{ height: '50%', mb: 3, backgroundColor: "background.default", zIndex: 1000 }}
+        width="100%"
+        animation="wave"
+        variant="rounded"
+      />
+      <Skeleton // Footer
+        sx={{ height: '25%', backgroundColor: "background.default", zIndex: 1000 }}
+        width="100%"
+        animation="wave"
+        variant="rounded"
+      />
+    </Stack>
+  );
+};
+
+export default Loading;

--- a/src/pages/loading.tsx
+++ b/src/pages/loading.tsx
@@ -4,19 +4,19 @@ const Loading = () => {
   return (
     <Stack sx={{ background: 'white'}} position="absolute" zIndex={1000} height="100%" width="100%" direction="column">
       <Skeleton // Header
-        sx={{ height: '20%', mb: 3, backgroundColor: "background.default", zIndex: 1000 }}
+        sx={{ height: '20%', mb: 3 }}
         width="100%"
         animation="wave"
         variant="rounded"
       />
       <Skeleton // Main
-        sx={{ height: '50%', mb: 3, backgroundColor: "background.default", zIndex: 1000 }}
+        sx={{ height: '50%', mb: 3 }}
         width="100%"
         animation="wave"
         variant="rounded"
       />
       <Skeleton // Footer
-        sx={{ height: '25%', backgroundColor: "background.default", zIndex: 1000 }}
+        sx={{ height: '25%' }}
         width="100%"
         animation="wave"
         variant="rounded"


### PR DESCRIPTION
The goal here is to show a skeleton component in overlay mode while translated content has not been properly fetched yet.