### PR TITLE
Feature/pn 14004

### DIFF
--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::LanguageExtensions
-Description: Template CloudFormation per creare un bucket S3 e una distribuzione CloudFront con OAI
+Description: Template CloudFormation for pn-showcase site.
 
 Parameters:
   Name:
@@ -19,21 +19,6 @@ Parameters:
   HostedZoneId:
     Description: "Hosted Zone Id in which you want to add record"
     Type: String
-
-  AlternateWebDomain:
-    Description: "Alternate Domain name for the webapp"
-    Type: String
-    Default: ""
-
-  AlternateWebDomainReferenceToSite:
-    Description: true if the website must be reachable using the AlternateWebDomain
-    Type: String
-    Default: "true"
-
-  AlternateHostedZoneId:
-    Description: Hosted Zone Id in which you want to add alternate DNS
-    Type: String
-    Default: ""
 
   WebCertificateArn:
     Description: "ACM Web Certificate ARN"
@@ -65,7 +50,7 @@ Parameters:
     Default: ''
 
   CmsCloudfrontDistName:
-    Description: 'Cloufront distibution used for hosting CMS version of showcase site, unique for all envs, located on CMS team's AWS account'
+    Description: 'Cloufront distibution used for hosting CMS version of showcase site, unique for all envs, located on CMS aws account '
     Type: String
     Default: 'd3g8ypiee9w1jl.cloudfront.net'
 
@@ -118,25 +103,7 @@ Conditions:
     - !Ref MultiDomainCertificateArn
     - ''
 
-  CreateDNSname: !Equals [ !Ref WebDomainReferenceToSite, "true" ]
-
   HasLogsBucket: !Not [ !Equals [ !Ref S3LogsBucket, "-" ] ]
-
-  # CreateAlternateDNSname:
-  #   Fn::And:
-  #     - Fn::Not:
-  #         - Fn::Equals: [ !Ref AlternateWebDomain, "" ]
-  #     - !Equals [ !Ref AlternateWebDomainReferenceToSite, "true" ]
-
-  # BothDNSNames: !And [ !Condition CreateDNSname, !Condition CreateAlternateDNSname ]
-
-  # OnlyPrimaryDNSName: !And [ !Condition CreateDNSname, !Not [ !Condition CreateAlternateDNSname ] ]
-
-  # OnlyAlternateDNSName: !And [ !Not [ !Condition CreateDNSname ], !Condition CreateAlternateDNSname ]
-
-  # CreatePrimaryAliasRecord: !Not [ !Equals [ !Ref HostedZoneId, "" ] ]
-
-  # CreateAlternateAliasRecord: !Not [ !Equals [ !Ref AlternateHostedZoneId, "" ] ]
 
   CreateExternalRecordsOutput: !And
     - !Not
@@ -422,7 +389,7 @@ Resources:
       - []
     - DNSRecord&{DomainIndex}:
         Type: AWS::Route53::RecordSet
-        Condition: CreateInternalRecords
+        Condition: UseMultiDomainCertificate
         Properties:
           Name: !Select
             - 0
@@ -450,19 +417,6 @@ Resources:
         DNSName: !GetAtt WebsiteCDN.DomainName
         EvaluateTargetHealth: false
         HostedZoneId: Z2FDTNDATAQYW2
-
-  # commented out as not anymore in use
-  # AlternateRoute53RecordSetGroup:
-  #   Condition: CreateAlternateAliasRecord
-  #   Type: AWS::Route53::RecordSet
-  #   Properties:
-  #     Name: !Ref AlternateWebDomain
-  #     Type: A
-  #     HostedZoneId: !Ref AlternateHostedZoneId
-  #     AliasTarget:
-  #       DNSName: !GetAtt WebsiteCDN.DomainName
-  #       EvaluateTargetHealth: false
-  #       HostedZoneId: Z2FDTNDATAQYW2
 
   ##
   ## Rewrite rule based on example provided by aws at https://github.com/aws-samples/amazon-cloudfront-functions/blob/main/url-rewrite-single-page-apps/index.js

--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -105,6 +105,7 @@ Conditions:
   CreateDNSname: !Equals [ !Ref WebDomainReferenceToSite, "true" ]
 
   HasLogsBucket: !Not [ !Equals [ !Ref S3LogsBucket, "-" ] ]
+  
   CreateAlternateDNSname:
     Fn::And:
       - Fn::Not:

--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -1,4 +1,6 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::LanguageExtensions
+Description: Template CloudFormation per creare un bucket S3 e una distribuzione CloudFront con OAI
 
 Parameters:
   Name:
@@ -37,6 +39,35 @@ Parameters:
     Description: "ACM Web Certificate ARN"
     Type: String
 
+  MultiDomainCertificateArn:
+    Description: "ACM Multi-Domain Certificate ARN"
+    Type: String
+    Default: ""
+
+  MultiDomainAliases:
+    Description: "List of alternate names to use with the multi-domain certificate"
+    Type: CommaDelimitedList
+    Default: ""
+
+  Environment:
+    Type: String
+    Description: "Current environment (e.g. dev, test, uat, hotfix, prod) "
+    AllowedValues:
+      - dev
+      - test
+      - uat
+      - hotfix
+      - prod
+
+  MultiDomainCertInternalAliasesWithZones:
+    Type: CommaDelimitedList
+    Description: 'List of internal domains included in the certificate with relative zone ID (format: domain|zoneid)'
+    
+  MultiDomainCertExternalAliasesWithZones:
+    Type: CommaDelimitedList
+    Description: 'List of external domains included in the certificate with relative zone ID (format: domain|zoneid)'
+    Default: ""
+
   WebApiUrl:
     Description: "The Url of web API: useful for content-security-policy"
     Type: String
@@ -67,42 +98,32 @@ Parameters:
     Description: Access Log bucket name
 
 Conditions:
-  # If domain is used in certificate, add this domain to CloudFront
-  CreateDNSname: !Equals
-    - !Ref WebDomainReferenceToSite
-    - "true"
+  UseMultiDomainCertificate: !Not [ !Equals [ !Ref MultiDomainCertificateArn, "" ] ]
 
-  # If domain is used in certificate, add this domain to CloudFront
-  HasLogsBucket: !Not [!Equals [!Ref S3LogsBucket, "-" ]]
+  NotUseMultiDomainCertificate: !Equals [ !Ref MultiDomainCertificateArn, "" ]
 
-  # If alternate domain is provided and is used in certificate, add this domain to CloudFront
+  CreateDNSname: !Equals [ !Ref WebDomainReferenceToSite, "true" ]
+
+  HasLogsBucket: !Not [ !Equals [ !Ref S3LogsBucket, "-" ] ]
   CreateAlternateDNSname:
     Fn::And:
       - Fn::Not:
-          - Fn::Equals:
-              - !Ref AlternateWebDomain
-              - ""
-      - !Equals
-        - !Ref AlternateWebDomainReferenceToSite
-        - "true"
+          - Fn::Equals: [ !Ref AlternateWebDomain, "" ]
+      - !Equals [ !Ref AlternateWebDomainReferenceToSite, "true" ]
 
-  # Condition combination to handle CDN alias array without NoValue
-  BothDNSNames:
-    !And [!Condition CreateDNSname, !Condition CreateAlternateDNSname]
-  OnlyPrimaryDNSName:
-    !And [!Condition CreateDNSname, !Not [!Condition CreateAlternateDNSname]]
-  OnlyAlternateDNSName:
-    !And [!Not [!Condition CreateDNSname], !Condition CreateAlternateDNSname]
+  # BothDNSNames: !And [ !Condition CreateDNSname, !Condition CreateAlternateDNSname ]
 
-  CreatePrimaryAliasRecord: !Not
-    - !Equals
-      - !Ref HostedZoneId
-      - ""
+  # OnlyPrimaryDNSName: !And [ !Condition CreateDNSname, !Not [ !Condition CreateAlternateDNSname ] ]
 
-  CreateAlternateAliasRecord: !Not
-    - !Equals
-      - !Ref AlternateHostedZoneId
-      - ""
+  # OnlyAlternateDNSName: !And [ !Not [ !Condition CreateDNSname ], !Condition CreateAlternateDNSname ]
+
+  # CreatePrimaryAliasRecord: !Not [ !Equals [ !Ref HostedZoneId, "" ] ]
+
+  # CreateAlternateAliasRecord: !Not [ !Equals [ !Ref AlternateHostedZoneId, "" ] ]
+
+  CreateExternalRecordsOutput: !And
+    - !Not [ !Equals [ !Ref MultiDomainCertificateArn, "" ] ]
+    - !Not [ !Equals [ !Join [ "", !Ref MultiDomainCertExternalAliasesWithZones ], "" ] ]
 
 Resources:
   # - CloudFront User used for WebApp S3 Bucket access
@@ -206,16 +227,9 @@ Resources:
       DistributionConfig:
         Comment: CDN for S3-backed website
         Aliases: !If
-          - BothDNSNames
+          - NotUseMultiDomainCertificate
           - - !Ref WebDomain
-            - !Ref AlternateWebDomain
-          - !If
-            - OnlyPrimaryDNSName
-            - - !Ref WebDomain
-            - !If
-              - OnlyAlternateDNSName
-              - - !Ref AlternateWebDomain
-              - !Ref AWS::NoValue
+          - !Ref MultiDomainAliases
         Enabled: "true"
         CacheBehaviors:
           - AllowedMethods:
@@ -310,11 +324,14 @@ Resources:
             - Bucket: !Sub ${S3LogsBucket}.s3.eu-central-1.amazonaws.com
               IncludeCookies: false
             - !Ref AWS::NoValue
-        ViewerCertificate:
-          AcmCertificateArn: !Ref WebCertificateArn
-          MinimumProtocolVersion: TLSv1.2_2021
-          SslSupportMethod: sni-only
-  #        WebACLId: !GetAtt ApiWafWebAcl.Arn
+        ViewerCertificate: !If
+          - UseMultiDomainCertificate
+          - AcmCertificateArn: !Ref MultiDomainCertificateArn
+            MinimumProtocolVersion: TLSv1.2_2021
+            SslSupportMethod: sni-only
+          - AcmCertificateArn: !Ref WebCertificateArn
+            MinimumProtocolVersion: TLSv1.2_2021
+            SslSupportMethod: sni-only
 
   DefaultHeaderPolicy:
     Type: AWS::CloudFront::ResponseHeadersPolicy
@@ -322,7 +339,6 @@ Resources:
       ResponseHeadersPolicyConfig:
         Name: !Sub "${Name}-headerPolicy"
         SecurityHeadersConfig:
-          # add_header Content-Security-Policy
           ContentSecurityPolicy:
             ContentSecurityPolicy:
               Fn::Join:
@@ -360,8 +376,32 @@ Resources:
             Preload: false
             Override: true
 
+  #Fn::ForEach to create internal dns records dynamically
+  Fn::ForEach::DnsRecords:
+    - DomainIndex
+    - !Ref MultiDomainCertInternalAliasesWithZones
+    - DNSRecord&{DomainIndex}:
+        Type: AWS::Route53::RecordSet
+        Condition: UseMultiDomainCertificate
+        Properties:
+          Name: !Select
+            - 0
+            - !Split
+              - '|'
+              - !Ref DomainIndex
+          Type: A
+          HostedZoneId: !Select
+            - 1
+            - !Split
+              - '|'
+              - !Ref DomainIndex
+          AliasTarget:
+            DNSName: !GetAtt WebsiteCDN.DomainName
+            EvaluateTargetHealth: false
+            HostedZoneId: Z2FDTNDATAQYW2
+
   Route53RecordSetGroup:
-    Condition: CreatePrimaryAliasRecord
+    Condition: NotUseMultiDomainCertificate
     Type: AWS::Route53::RecordSet
     Properties:
       Name: !Ref WebDomain
@@ -372,18 +412,18 @@ Resources:
         EvaluateTargetHealth: false
         HostedZoneId: Z2FDTNDATAQYW2
 
-  #Alternate domain Route53 record
-  AlternateRoute53RecordSetGroup:
-    Condition: CreateAlternateAliasRecord
-    Type: AWS::Route53::RecordSet
-    Properties:
-      Name: !Ref AlternateWebDomain
-      Type: A
-      HostedZoneId: !Ref AlternateHostedZoneId
-      AliasTarget:
-        DNSName: !GetAtt WebsiteCDN.DomainName
-        EvaluateTargetHealth: false
-        HostedZoneId: Z2FDTNDATAQYW2
+  # commented out as not anymore in use
+  # AlternateRoute53RecordSetGroup:
+  #   Condition: CreateAlternateAliasRecord
+  #   Type: AWS::Route53::RecordSet
+  #   Properties:
+  #     Name: !Ref AlternateWebDomain
+  #     Type: A
+  #     HostedZoneId: !Ref AlternateHostedZoneId
+  #     AliasTarget:
+  #       DNSName: !GetAtt WebsiteCDN.DomainName
+  #       EvaluateTargetHealth: false
+  #       HostedZoneId: Z2FDTNDATAQYW2
 
   ##
   ## Rewrite rule based on example provided by aws at https://github.com/aws-samples/amazon-cloudfront-functions/blob/main/url-rewrite-single-page-apps/index.js
@@ -543,3 +583,22 @@ Outputs:
   TooManyRequestsAlarmArn:
     Value: !GetAtt TooManyRequestsAlarm.Arn
     Description: ARN of distribution too many requests alarm
+
+  #Fn::ForEach to print output with instructions related to the creation of dns records (for external zones)
+  Fn::ForEach::ManualRecords:
+    - ExternalDomain
+    - !If
+        - CreateExternalRecordsOutput
+        - !Ref MultiDomainCertExternalAliasesWithZones
+        - []
+    - ExternalDNSRecord&{ExternalDomain}:
+        Value: !Sub |
+          Create DNS record in the external zone -->
+          Domain: ${WebDomain}
+          Zone: ${ZoneName}
+          Type: A (Alias)
+          Value: ${DistributionName}
+        DomainName: !Select [ 0, !Split [ "|", !Ref ExternalDomain ] ]
+        ZoneName: !Select [ 1, !Split [ "|", !Ref ExternalDomain ] ]
+        DistributionName: !GetAtt WebsiteCDN.DomainName
+      Condition: CreateExternalRecordsOutput

--- a/aws-cdn-templates/one-cdn.yaml
+++ b/aws-cdn-templates/one-cdn.yaml
@@ -59,14 +59,25 @@ Parameters:
       - hotfix
       - prod
 
+  WebBaseDnsZoneName:
+    Description: 'Base domain name used as main endpoint for pn-showcase site, used as alias on for the cloudfront distribution on CMS team''s account'
+    Type: String
+    Default: ''
+
+  CmsCloudfrontDistName:
+    Description: 'Cloufront distibution used for hosting CMS version of showcase site, unique for all envs, located on CMS team's AWS account'
+    Type: String
+    Default: 'd3g8ypiee9w1jl.cloudfront.net'
+
   MultiDomainCertInternalAliasesWithZones:
     Type: CommaDelimitedList
     Description: 'List of internal domains included in the certificate with relative zone ID (format: domain|zoneid)'
-    
+    Default: ''
+
   MultiDomainCertExternalAliasesWithZones:
     Type: CommaDelimitedList
-    Description: 'List of external domains included in the certificate with relative zone ID (format: domain|zoneid)'
-    Default: ""
+    Description: 'List of external domains included in the certificate with relative zone ID (format: domain|zonename)'
+    Default: ''
 
   WebApiUrl:
     Description: "The Url of web API: useful for content-security-policy"
@@ -98,19 +109,24 @@ Parameters:
     Description: Access Log bucket name
 
 Conditions:
-  UseMultiDomainCertificate: !Not [ !Equals [ !Ref MultiDomainCertificateArn, "" ] ]
+  UseMultiDomainCertificate: !Not
+    - !Equals
+      - !Ref MultiDomainCertificateArn
+      - ''
 
-  NotUseMultiDomainCertificate: !Equals [ !Ref MultiDomainCertificateArn, "" ]
+  NotUseMultiDomainCertificate: !Equals
+    - !Ref MultiDomainCertificateArn
+    - ''
 
   CreateDNSname: !Equals [ !Ref WebDomainReferenceToSite, "true" ]
 
   HasLogsBucket: !Not [ !Equals [ !Ref S3LogsBucket, "-" ] ]
-  
-  CreateAlternateDNSname:
-    Fn::And:
-      - Fn::Not:
-          - Fn::Equals: [ !Ref AlternateWebDomain, "" ]
-      - !Equals [ !Ref AlternateWebDomainReferenceToSite, "true" ]
+
+  # CreateAlternateDNSname:
+  #   Fn::And:
+  #     - Fn::Not:
+  #         - Fn::Equals: [ !Ref AlternateWebDomain, "" ]
+  #     - !Equals [ !Ref AlternateWebDomainReferenceToSite, "true" ]
 
   # BothDNSNames: !And [ !Condition CreateDNSname, !Condition CreateAlternateDNSname ]
 
@@ -123,8 +139,28 @@ Conditions:
   # CreateAlternateAliasRecord: !Not [ !Equals [ !Ref AlternateHostedZoneId, "" ] ]
 
   CreateExternalRecordsOutput: !And
-    - !Not [ !Equals [ !Ref MultiDomainCertificateArn, "" ] ]
-    - !Not [ !Equals [ !Join [ "", !Ref MultiDomainCertExternalAliasesWithZones ], "" ] ]
+    - !Not
+      - !Equals
+        - !Ref MultiDomainCertificateArn
+        - ''
+    - !Not
+      - !Equals
+        - !Join
+          - ''
+          - !Ref MultiDomainCertExternalAliasesWithZones
+        - ''
+
+  CreateInternalRecords: !And
+    - !Not
+      - !Equals
+        - !Ref MultiDomainCertificateArn
+        - ''
+    - !Not
+      - !Equals
+        - !Join
+          - ''
+          - !Ref MultiDomainCertInternalAliasesWithZones
+        - ''
 
 Resources:
   # - CloudFront User used for WebApp S3 Bucket access
@@ -355,7 +391,7 @@ Resources:
                     style-src 'self' 'unsafe-inline' https://privacyportalde-cdn.onetrust.com/; \
                     worker-src 'none'; \
                     font-src 'self'; \
-                    frame-ancestors 'self' ; \
+                    frame-ancestors 'self' https://${WebBaseDnsZoneName}/ https://${CmsCloudfrontDistName}/ ; \
                     img-src 'self' https://assets.cdn.io.italia.it/ data:"
             Override: true
           # add_header X-Content-Type-Options "nosniff";
@@ -380,10 +416,13 @@ Resources:
   #Fn::ForEach to create internal dns records dynamically
   Fn::ForEach::DnsRecords:
     - DomainIndex
-    - !Ref MultiDomainCertInternalAliasesWithZones
+    - !If
+      - CreateInternalRecords
+      - !Ref MultiDomainCertInternalAliasesWithZones
+      - []
     - DNSRecord&{DomainIndex}:
         Type: AWS::Route53::RecordSet
-        Condition: UseMultiDomainCertificate
+        Condition: CreateInternalRecords
         Properties:
           Name: !Select
             - 0
@@ -402,7 +441,6 @@ Resources:
             HostedZoneId: Z2FDTNDATAQYW2
 
   Route53RecordSetGroup:
-    Condition: NotUseMultiDomainCertificate
     Type: AWS::Route53::RecordSet
     Properties:
       Name: !Ref WebDomain
@@ -567,10 +605,10 @@ Outputs:
   WebDomainUrl:
     Value: !Sub "https://${WebDomain}"
     Description: Site access URL
-  AlternateWebDomainUrl:
-    Condition: CreateAlternateDNSname
-    Value: !Sub "http://${AlternateWebDomain}"
-    Description: Alternate site access URL
+  # AlternateWebDomainUrl:
+  #   Condition: CreateAlternateDNSname
+  #   Value: !Sub "http://${AlternateWebDomain}"
+  #   Description: Alternate site access URL
 
   # Distribution ID
   DistributionId:
@@ -589,17 +627,26 @@ Outputs:
   Fn::ForEach::ManualRecords:
     - ExternalDomain
     - !If
-        - CreateExternalRecordsOutput
-        - !Ref MultiDomainCertExternalAliasesWithZones
-        - []
+      - CreateExternalRecordsOutput
+      - !Ref MultiDomainCertExternalAliasesWithZones
+      - []
     - ExternalDNSRecord&{ExternalDomain}:
-        Value: !Sub |
-          Create DNS record in the external zone -->
-          Domain: ${WebDomain}
-          Zone: ${ZoneName}
-          Type: A (Alias)
-          Value: ${DistributionName}
-        DomainName: !Select [ 0, !Split [ "|", !Ref ExternalDomain ] ]
-        ZoneName: !Select [ 1, !Split [ "|", !Ref ExternalDomain ] ]
-        DistributionName: !GetAtt WebsiteCDN.DomainName
-      Condition: CreateExternalRecordsOutput
+        Value: !Sub
+          - |
+            Create DNS record in the external zone -->
+            Domain: ${DomainName}
+            Zone: ${ZoneName}
+            Type: A (Alias)
+            Value: ${DistributionName}
+          - DomainName: !Select
+              - 0
+              - !Split
+                - '|'
+                - !Ref ExternalDomain
+            ZoneName: !Select
+              - 1
+              - !Split
+                - '|'
+                - !Ref ExternalDomain
+            DistributionName: !GetAtt WebsiteCDN.DomainName
+        Condition: CreateExternalRecordsOutput


### PR DESCRIPTION
La modifica ha l'obbiettivo di integrare il supporto per le nuove configurazioni necessarie per lo switch a gestione tramite CMS.

parametri aggiunti:

Environment:
```yaml
Type: String
Description: "Current environment (e.g. dev, test, uat, hotfix, prod) "
AllowedValues:
  - dev
  - test
  - uat
  - hotfix
  - prod
```
Il valore rappresenta l'ambiente corrente e viene passato tramite variabile `<env_type>` in pn-cicd, durante l'esecuzione della pipeline, attualmente non utilizzato, ma utile per utilizzi futuri (secondo step switch) in quanto la repository pn-showcase-site non utilizza pn-configuration per la gestione dei parametri cloudformation per i diversi ambienti.

WebBaseDnsZoneName:
```yaml
Description: 'Base domain name used as main endpoint for pn-showcase site, used as alias on for the cloudfront distribution on CMS team''s account'
Type: String
Default: ''
```
Contiene il nome di dominio base della zona notifichedigitali.it (per ogni ambiente), viene passato tramite il nuovo output terraform "Core_DnsZoneName": necessario per essere inserito nella DefaultheaderPolicy sotto le direttive "frame-ancestors 'self'" come dominio autorizzato a chiamare tramite iframe la distribuzione cloudfront permettendo il funzionamento dell'iframe, verrà utilizzato inoltre nel secondo step della migrazione come dominio di destinazione per i redirect 301 verso il dominio definitivo, che corrisponde appunto al nome dns della zona, utilizzato come alias dal CMS.

CmsCloudfrontDistName:
```yaml
Description: 'Cloufront distribution used for hosting CMS version of showcase site, unique for all envs, located on CMS aws account '
Type: String
Default: 'd3g8ypiee9w1jl.cloudfront.net'
```
Contiene il nome di dominio della distribuzione cloudfront messa a disposizione dal team CMS su cui è hostata la nuova versione del sito pn-showcase, sull'account AWS di proprietà del team CMS, il valore è fisso a default in quanto unico per tutti gli ambienti, è necessario per essere utilizzato come dominio autorizzato per essere inserito nella DefaultheaderPolicy sotto le direttive "frame-ancestors 'self'" come dominio autorizzato a chiamare tramite iframe la distribuzione cloudfront permettendo il funzionamento dell'iframe, come da raccomandazione del team CMS.

MultiDomainCertificateArn:
```yaml
Description: "ACM Multi-Domain Certificate ARN"
Type: String
Default: ""
```
Contiene l'arn del certificato multidominio creato tramite terraform, il valore viene passato tramite output terraform "Core_LandingMultiDomainCertificateArn", necessario per eseguire l'associazione del nuovo certificato alla distribuzione Cloudfront.

MultiDomainAliases:
```yaml
Description: "List of alternate names to use with the multi-domain certificate"
Type: CommaDelimitedList
Default: ""
```
Il valore contiene una comma delimited list con nomi di dominio associati al nuovo certificato, viene utilizzato sotto forma di array da associare alla distribuzione cloudfront come alternate aliases, viene passato tramite l'output terraform "Core_LandingMultiDomainCertJoinedDomains".

MultiDomainCertInternalAliasesWithZones:
```yaml
Type: CommaDelimitedList
Description: 'List of internal domains included in the certificate with relative zone ID (format: domain|zoneid)'
Default: ''
```
Viene passato tramite l'output terraform 'Core_LandingMultiDomainCertInternalDomainsZonesMap', Il volore contiene una comma delimited list, con i nomi dei domini relativi alle zone interne mappati con i rispettivi ZoneIDdelimitati con | (cloudformation non supporta parametri Map), da cui viene rimossa la coppia dominio zona relativa al dominio principale utilizzato dalla distribuzione cloudfront, in modo da evitare conflitti durante fase di deploy o eventuali rollback (il record dns del dominio principale è già presente in place nella vecchia versione del template e non verrà modificato durante le operazioni).

MultiDomainCertExternalAliasesWithZones:
```yaml
Type: CommaDelimitedList
Description: 'List of external domains included in the certificate with relative zone ID (format: domain|zonename)'
Default: ''
```
Viene passato tramite l'output terraform 'Core_LandingMultiDomainCertExternalDomainsZonesMap', contiene una comma delimited list con i nomi dei domini relativi alle zone esterne mappate con il nome della rispettiva zona esterna delimitati con | (cloudformation non supporta parametri Map), viene utilizzato soltanto come output con le istruzioni relative alla creazione manuale di record su un'eventuale zona esterna.

Condition aggiuntive:

UseMultiDomainCertificate:
```yaml
!Not
  - !Equals
    - !Ref MultiDomainCertificateArn
    - ''
```
Condizione principale che gestisce l'associazione del certificato alla distribuzione cloudfront e la creazione dei record dns multipli tramite Fn::ForEach.

NotUseMultiDomainCertificate:
```yaml
!Equals
  - !Ref MultiDomainCertificateArn
  - ''
```
Negazione della condizione precedente utilizzata per associare condizionalmente gli aliases multipli presenti nel parametro 'MultiDomainAliases' come seconda opzione.

CreateExternalRecordsOutput:
```yaml
!And
  - !Not
    - !Equals
      - !Ref MultiDomainCertificateArn
      - ''
  - !Not
    - !Equals
      - !Join
        - ''
        - !Ref MultiDomainCertExternalAliasesWithZones
      - ''
```
Condizione utilizzata per la creazione condizionale degli output con le istruzioni relative alla creazione manuale di record dns su account esterni (negli ambienti inferiori la zona notifichedigitali.pagopa.it è esterna in quanto è presente solo in prod).

CreateInternalRecords:
```yaml
!And
  - !Not
    - !Equals
      - !Ref MultiDomainCertificateArn
      - ''
  - !Not
    - !Equals
      - !Join
        - ''
        - !Ref MultiDomainCertInternalAliasesWithZones
      - ''
```
Condizione utilizzata all'interno del blocco ForEach che crea i record dns per gli alternate names associati alla distribuzione in maniera dinamica, necessaria per presentare un array vuoto [] all'indice ForEach nel caso in cui il parametro MultiDomainCertInternalAliasesWithZones sia vuoto: è necessario presentare un array vuoto al ciclo ForEach anche nel caso in cui le risorse non vengano create, appunto questa condizione associata all' "index" del ciclo foreach viene valutata a livello di transform, quindi prima che le condizioni associate alle risorse logiche vengano valutate.

Modifiche principali:

Route53RecordSetGroup:
```yaml
Type: AWS::Route53::RecordSet
Properties:
  Name: !Ref WebDomain
  Type: A
  HostedZoneId: !Ref HostedZoneId
  AliasTarget:
    DNSName: !GetAtt WebsiteCDN.DomainName
    EvaluateTargetHealth: false
    HostedZoneId: Z2FDTNDATAQYW2
```
Rimossa condition precedente, ora la risorsa con il record principale viene sempre creata e non modificata durante la fase di update e rollback.

blocco Fn::ForEach utilizzato per creare record dns relativi ai domini appartenenti all' account di riferimento,
necessario essendo l'elenco degli stessi non simmetrico tra i vari env (solo per prod la zona notifichedigitali.pagopa.it è considerata una zona zona interna)
```yaml
Fn::ForEach::DnsRecords:
  - DomainIndex
  - !If
    - CreateInternalRecords
    - !Ref MultiDomainCertInternalAliasesWithZones
    - []
  - DNSRecord&{DomainIndex}:
      Type: AWS::Route53::RecordSet
      Condition: UseMultiDomainCertificate
      Properties:
        Name: !Select
          - 0
          - !Split
            - '|'
            - !Ref DomainIndex
        Type: A
        HostedZoneId: !Select
          - 1
          - !Split
            - '|'
            - !Ref DomainIndex
        AliasTarget:
          DNSName: !GetAtt WebsiteCDN.DomainName
          EvaluateTargetHealth: false
          HostedZoneId: Z2FDTNDATAQYW2
```
Creazione dinamica dei record dns per i domini relativi agli alias aggiuntivi fatta eccezione a quello relativo al nome principale (record già presente).

WebsiteCDN:
```yaml
ViewerCertificate: !If
  - UseMultiDomainCertificate
  - AcmCertificateArn: !Ref MultiDomainCertificateArn
    MinimumProtocolVersion: TLSv1.2_2021
    SslSupportMethod: sni-only
  - AcmCertificateArn: !Ref WebCertificateArn
    MinimumProtocolVersion: TLSv1.2_2021
    SslSupportMethod: sni-only
    
Aliases: !If
  - NotUseMultiDomainCertificate
  - - !Ref WebDomain
  - !Ref MultiDomainAliases
```

DefaultHeaderPolicy:
```yaml
"frame-ancestors 'self' https://${WebBaseDnsZoneName}/ https://${CmsCloudfrontDistName}/ ;"
```
Inseriti i valori relativi al dominio definitivo del sito vetrina, e il nome dominio della distribuzione cloudfront su cui è hostata la versione del sito CMS tramite i parametri CmsCloudfrontDistName:

Fn::ForEach::ManualRecords:
```yaml
- ExternalDomain
- !If
  - CreateExternalRecordsOutput
  - !Ref MultiDomainCertExternalAliasesWithZones
  - []
- ExternalDNSRecord&{ExternalDomain}:
    Value: !Sub
      - |
        Create DNS record in the external zone -->
        Domain: ${DomainName}
        Zone: ${ZoneName}
        Type: A (Alias)
        Value: ${DistributionName}
      - DomainName: !Select
          - 0
          - !Split
            - '|'
            - !Ref ExternalDomain
        ZoneName: !Select
          - 1
          - !Split
            - '|'
            - !Ref ExternalDomain
        DistributionName: !GetAtt WebsiteCDN.DomainName
    Condition: CreateExternalRecordsOutput
```
Utilizzata per generazione dinamica di output con informazioni relative alla creazione manuale di record per eventuali zone esterne (su account terzi).
```` ▋