### PR TITLE
PN-14340 - Force pagination of pickup page to show alway 10 rows per page

### DIFF
--- a/src/components/Ritiro/OperatorsList.tsx
+++ b/src/components/Ritiro/OperatorsList.tsx
@@ -12,7 +12,6 @@ import {
 import { RaddOperator } from "../../model";
 import { useRef, useState } from "react";
 import CustomPagination from "../CustomPagination";
-import { useTranslation } from "../../hook/useTranslation";
 
 type Props = {
   rows: RaddOperator[];
@@ -21,7 +20,6 @@ type Props = {
 function OperatorsList({ rows }: Readonly<Props>) {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
-  const { t } = useTranslation(["pickup"]);
 
   const listContainerRef = useRef<HTMLUListElement | null>(null);
 
@@ -105,7 +103,7 @@ function OperatorsList({ rows }: Readonly<Props>) {
           page={page}
           onPageChange={handleChangePage}
           onRowsPerPageChange={handleChangeRowsPerPage}
-          rowsPerPageOptions={[10, 20, 50]}
+          rowsPerPageOptions={[10]}
         />
         <CustomPagination pagination={pagination} onChange={handleChangePage} />
       </Stack>

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -10,7 +10,6 @@ import { TablePagination, Stack, TableSortLabel } from "@mui/material";
 import { RaddOperator } from "../../model";
 import { useRef, useState } from "react";
 import CustomPagination from "../CustomPagination";
-import { useTranslation } from "../../hook/useTranslation";
 
 type Props = {
   rows: RaddOperator[];
@@ -45,7 +44,6 @@ function descendingComparator(a: any, b: any, orderBy: string) {
 function OperatorsTable({ rows }: Readonly<Props>) {
   const [orderBy, setOrderBy] = useState("city");
   const [order, setOrder] = useState<"asc" | "desc">("asc");
-  const { t } = useTranslation(["pickup"]);
 
   const sortedRows: RaddOperator[] = stableSort(
     rows,
@@ -154,7 +152,7 @@ function OperatorsTable({ rows }: Readonly<Props>) {
             page={page}
             onPageChange={handleChangePage}
             onRowsPerPageChange={handleChangeRowsPerPage}
-            rowsPerPageOptions={[10, 20, 50]}
+            rowsPerPageOptions={[10]}
           />
           <CustomPagination
             pagination={pagination}


### PR DESCRIPTION
## How to test
- Start application and navigate to `/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7/`
- Check that the rows per page selector is not showed and table has 10 rows (also for mobile view)