### PR TITLE
[B2BP-1221] Fix OperatorsTable pagination bug inside iFrame

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/Ritiro/OperatorsList.tsx
+++ b/src/components/Ritiro/OperatorsList.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   ListItem,
   Typography,
@@ -10,7 +8,7 @@ import {
   TablePagination,
 } from "@mui/material";
 import { RaddOperator } from "../../model";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CustomPagination from "../CustomPagination";
 
 type Props = {
@@ -22,6 +20,17 @@ function OperatorsList({ rows }: Readonly<Props>) {
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
   const listContainerRef = useRef<HTMLUListElement | null>(null);
+
+  const resizeParentIframe = () => {
+    // This function is to be called if parentIframe.resize() does not work
+    // Current use cases: when changing pagination size, when changing to page with less/more elements
+    if (window.parentIframe) {
+      window.parentIframe.sendMessage({
+        type: "resize",
+        newChildHeight: document.body.scrollHeight,
+      });
+    }
+  };
 
   const handleChangePage = (_event: any, newPage: number | null) => {
     if (newPage !== null) {
@@ -36,12 +45,15 @@ function OperatorsList({ rows }: Readonly<Props>) {
     setPage(0);
     setRowsPerPage(parseInt(event.target.value, 10));
   };
+
   const pagination = {
     size: rowsPerPage,
     totalElements: rows.length,
     numOfDisplayedPages: Math.min(Math.ceil(rows.length / rowsPerPage), 3),
     currentPage: page,
   };
+
+  useEffect(resizeParentIframe, [rowsPerPage, page]);
 
   return (
     <Stack>
@@ -103,7 +115,7 @@ function OperatorsList({ rows }: Readonly<Props>) {
           page={page}
           onPageChange={handleChangePage}
           onRowsPerPageChange={handleChangeRowsPerPage}
-          rowsPerPageOptions={[10]}
+          rowsPerPageOptions={[10, 30, 50]}
         />
         <CustomPagination pagination={pagination} onChange={handleChangePage} />
       </Stack>

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
-import { TablePagination, Stack, TableSortLabel } from '@mui/material';
-import { RaddOperator } from '../../model';
-import { useRef, useState, useEffect } from 'react';
-import CustomPagination from '../CustomPagination';
+import * as React from "react";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+import { TablePagination, Stack, TableSortLabel } from "@mui/material";
+import { RaddOperator } from "../../model";
+import { useRef, useState, useEffect } from "react";
+import CustomPagination from "../CustomPagination";
 
 declare global {
   interface Window {
     parentIframe?: {
       sendMessage: (message: {
-        type: 'resize';
+        type: "resize";
         newChildHeight: number;
       }) => void;
       scrollToOffset: (x: number, y: number) => void;
@@ -37,8 +37,8 @@ function stableSort(array: any[], comparator: (a: any, b: any) => number) {
   return stabilizedThis.map((el) => el[0]);
 }
 
-function getComparator(order: 'asc' | 'desc', orderBy: string) {
-  return order === 'desc'
+function getComparator(order: "asc" | "desc", orderBy: string) {
+  return order === "desc"
     ? (a: any, b: any) => descendingComparator(a, b, orderBy)
     : (a: any, b: any) => -descendingComparator(a, b, orderBy);
 }
@@ -54,20 +54,20 @@ function descendingComparator(a: any, b: any, orderBy: string) {
 }
 
 function OperatorsTable({ rows }: Readonly<Props>) {
-  const [orderBy, setOrderBy] = useState('city');
-  const [order, setOrder] = useState<'asc' | 'desc'>('asc');
+  const [orderBy, setOrderBy] = useState("city");
+  const [order, setOrder] = useState<"asc" | "desc">("asc");
 
   const sortedRows: RaddOperator[] = stableSort(
     rows,
     getComparator(order, orderBy),
   );
 
-  const keys = ['denomination', 'city', 'address', 'contacts'];
+  const keys = ["denomination", "city", "address", "contacts"];
   const columnNames: { [key: string]: string } = {
-    denomination: 'Denominazione',
-    city: 'Città',
-    address: 'Indirizzo',
-    contacts: 'Contatti',
+    denomination: "Denominazione",
+    city: "Città",
+    address: "Indirizzo",
+    contacts: "Contatti",
   };
 
   const [page, setPage] = useState(0);
@@ -80,7 +80,7 @@ function OperatorsTable({ rows }: Readonly<Props>) {
     // Current use cases: when changing pagination size, when changing to page with less/more elements
     if (window.parentIframe) {
       window.parentIframe.sendMessage({
-        type: 'resize',
+        type: "resize",
         newChildHeight: document.body.scrollHeight,
       });
     }
@@ -91,7 +91,7 @@ function OperatorsTable({ rows }: Readonly<Props>) {
   const handleChangePage = (_event: any, newPage: number | null) => {
     if (newPage !== null) {
       if (tableContainerRef.current) {
-        tableContainerRef.current.scrollIntoView({ behavior: 'smooth' });
+        tableContainerRef.current.scrollIntoView({ behavior: "smooth" });
       }
       setPage(newPage - 1);
     }
@@ -103,8 +103,8 @@ function OperatorsTable({ rows }: Readonly<Props>) {
   };
 
   const handleRequestSort = (property: string) => {
-    const isAsc = property === 'city' && order === 'asc';
-    setOrder(isAsc ? 'desc' : 'asc');
+    const isAsc = property === "city" && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
   };
 
   const pagination = {
@@ -118,17 +118,17 @@ function OperatorsTable({ rows }: Readonly<Props>) {
     <>
       <TableContainer component={Paper} ref={tableContainerRef}>
         <Table
-          sx={{ width: '100%', maxWidth: 1092 }}
-          aria-label='operators table'
+          sx={{ width: "100%", maxWidth: 1092 }}
+          aria-label="operators table"
         >
           <TableHead>
-            <TableRow sx={{ backgroundColor: '#FAFAFA' }}>
+            <TableRow sx={{ backgroundColor: "#FAFAFA" }}>
               {keys.map((key) => (
                 <TableCell key={key}>
                   <TableSortLabel
-                    disabled={key !== 'city'}
-                    active={key === 'city'}
-                    direction={key === 'city' ? order : 'asc'}
+                    disabled={key !== "city"}
+                    active={key === "city"}
+                    direction={key === "city" ? order : "asc"}
                     onClick={() => handleRequestSort(key)}
                   >
                     {columnNames[key]}
@@ -144,10 +144,10 @@ function OperatorsTable({ rows }: Readonly<Props>) {
                 <TableRow
                   key={`${row.denomination}-${index}`}
                   sx={{
-                    '&:last-child td, &:last-child th': { border: 0 },
+                    "&:last-child td, &:last-child th": { border: 0 },
                   }}
                 >
-                  <TableCell component='th' scope='row'>
+                  <TableCell component="th" scope="row">
                     {row.denomination}
                   </TableCell>
                   <TableCell>
@@ -165,13 +165,13 @@ function OperatorsTable({ rows }: Readonly<Props>) {
       {rows.length > 10 && (
         <Stack
           mt={3}
-          direction='row'
-          alignItems='center'
-          justifyContent='space-between'
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
         >
           <TablePagination
-            id='ritiroPagination'
-            component='div'
+            id="ritiroPagination"
+            component="div"
             count={rows.length}
             rowsPerPage={rowsPerPage}
             page={page}

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -18,7 +18,6 @@ declare global {
         type: "resize";
         newChildHeight: number;
       }) => void;
-      scrollToOffset: (x: number, y: number) => void;
     };
   }
 }

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -10,17 +9,6 @@ import { TablePagination, Stack, TableSortLabel } from "@mui/material";
 import { RaddOperator } from "../../model";
 import { useRef, useState, useEffect } from "react";
 import CustomPagination from "../CustomPagination";
-
-declare global {
-  interface Window {
-    parentIframe?: {
-      sendMessage: (message: {
-        type: "resize";
-        newChildHeight: number;
-      }) => void;
-    };
-  }
-}
 
 type Props = {
   rows: RaddOperator[];

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -58,7 +58,7 @@ function OperatorsTable({ rows }: Readonly<Props>) {
 
   const sortedRows: RaddOperator[] = stableSort(
     rows,
-    getComparator(order, orderBy),
+    getComparator(order, orderBy)
   );
 
   const keys = ["denomination", "city", "address", "contacts"];

--- a/src/components/Ritiro/OperatorsTable.tsx
+++ b/src/components/Ritiro/OperatorsTable.tsx
@@ -1,15 +1,27 @@
-import * as React from "react";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
-import Paper from "@mui/material/Paper";
-import { TablePagination, Stack, TableSortLabel } from "@mui/material";
-import { RaddOperator } from "../../model";
-import { useRef, useState } from "react";
-import CustomPagination from "../CustomPagination";
+import * as React from 'react';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import { TablePagination, Stack, TableSortLabel } from '@mui/material';
+import { RaddOperator } from '../../model';
+import { useRef, useState, useEffect } from 'react';
+import CustomPagination from '../CustomPagination';
+
+declare global {
+  interface Window {
+    parentIframe?: {
+      sendMessage: (message: {
+        type: 'resize';
+        newChildHeight: number;
+      }) => void;
+      scrollToOffset: (x: number, y: number) => void;
+    };
+  }
+}
 
 type Props = {
   rows: RaddOperator[];
@@ -25,8 +37,8 @@ function stableSort(array: any[], comparator: (a: any, b: any) => number) {
   return stabilizedThis.map((el) => el[0]);
 }
 
-function getComparator(order: "asc" | "desc", orderBy: string) {
-  return order === "desc"
+function getComparator(order: 'asc' | 'desc', orderBy: string) {
+  return order === 'desc'
     ? (a: any, b: any) => descendingComparator(a, b, orderBy)
     : (a: any, b: any) => -descendingComparator(a, b, orderBy);
 }
@@ -42,20 +54,20 @@ function descendingComparator(a: any, b: any, orderBy: string) {
 }
 
 function OperatorsTable({ rows }: Readonly<Props>) {
-  const [orderBy, setOrderBy] = useState("city");
-  const [order, setOrder] = useState<"asc" | "desc">("asc");
+  const [orderBy, setOrderBy] = useState('city');
+  const [order, setOrder] = useState<'asc' | 'desc'>('asc');
 
   const sortedRows: RaddOperator[] = stableSort(
     rows,
-    getComparator(order, orderBy)
+    getComparator(order, orderBy),
   );
 
-  const keys = ["denomination", "city", "address", "contacts"];
+  const keys = ['denomination', 'city', 'address', 'contacts'];
   const columnNames: { [key: string]: string } = {
-    denomination: "Denominazione",
-    city: "Città",
-    address: "Indirizzo",
-    contacts: "Contatti",
+    denomination: 'Denominazione',
+    city: 'Città',
+    address: 'Indirizzo',
+    contacts: 'Contatti',
   };
 
   const [page, setPage] = useState(0);
@@ -63,10 +75,23 @@ function OperatorsTable({ rows }: Readonly<Props>) {
 
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
+  const resizeParentIframe = () => {
+    // This function is to be called if parentIframe.resize() does not work
+    // Current use cases: when changing pagination size, when changing to page with less/more elements
+    if (window.parentIframe) {
+      window.parentIframe.sendMessage({
+        type: 'resize',
+        newChildHeight: document.body.scrollHeight,
+      });
+    }
+  };
+
+  useEffect(resizeParentIframe, [rowsPerPage, page]);
+
   const handleChangePage = (_event: any, newPage: number | null) => {
     if (newPage !== null) {
       if (tableContainerRef.current) {
-        tableContainerRef.current.scrollIntoView({ behavior: "smooth" });
+        tableContainerRef.current.scrollIntoView({ behavior: 'smooth' });
       }
       setPage(newPage - 1);
     }
@@ -78,8 +103,8 @@ function OperatorsTable({ rows }: Readonly<Props>) {
   };
 
   const handleRequestSort = (property: string) => {
-    const isAsc = property === "city" && order === "asc";
-    setOrder(isAsc ? "desc" : "asc");
+    const isAsc = property === 'city' && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
   };
 
   const pagination = {
@@ -93,17 +118,17 @@ function OperatorsTable({ rows }: Readonly<Props>) {
     <>
       <TableContainer component={Paper} ref={tableContainerRef}>
         <Table
-          sx={{ width: "100%", maxWidth: 1092 }}
-          aria-label="operators table"
+          sx={{ width: '100%', maxWidth: 1092 }}
+          aria-label='operators table'
         >
           <TableHead>
-            <TableRow sx={{ backgroundColor: "#FAFAFA" }}>
+            <TableRow sx={{ backgroundColor: '#FAFAFA' }}>
               {keys.map((key) => (
                 <TableCell key={key}>
                   <TableSortLabel
-                    disabled={key !== "city"}
-                    active={key === "city"}
-                    direction={key === "city" ? order : "asc"}
+                    disabled={key !== 'city'}
+                    active={key === 'city'}
+                    direction={key === 'city' ? order : 'asc'}
                     onClick={() => handleRequestSort(key)}
                   >
                     {columnNames[key]}
@@ -119,10 +144,10 @@ function OperatorsTable({ rows }: Readonly<Props>) {
                 <TableRow
                   key={`${row.denomination}-${index}`}
                   sx={{
-                    "&:last-child td, &:last-child th": { border: 0 },
+                    '&:last-child td, &:last-child th': { border: 0 },
                   }}
                 >
-                  <TableCell component="th" scope="row">
+                  <TableCell component='th' scope='row'>
                     {row.denomination}
                   </TableCell>
                   <TableCell>
@@ -140,19 +165,19 @@ function OperatorsTable({ rows }: Readonly<Props>) {
       {rows.length > 10 && (
         <Stack
           mt={3}
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
+          direction='row'
+          alignItems='center'
+          justifyContent='space-between'
         >
           <TablePagination
-            id="ritiroPagination"
-            component="div"
+            id='ritiroPagination'
+            component='div'
             count={rows.length}
             rowsPerPage={rowsPerPage}
             page={page}
             onPageChange={handleChangePage}
             onRowsPerPageChange={handleChangeRowsPerPage}
-            rowsPerPageOptions={[10]}
+            rowsPerPageOptions={[10, 30, 50]}
           />
           <CustomPagination
             pagination={pagination}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,12 @@
+export {};
+
+declare global {
+  interface Window {
+    parentIframe?: {
+      sendMessage: (message: {
+        type: "resize";
+        newChildHeight: number;
+      }) => void;
+    };
+  }
+}


### PR DESCRIPTION
### Problem:
A showcase website user changing the pagination size of an OperatorsTable would NOT cause the iFrame to resize accordingly.

### Cause:
iframe-resizer (the library currently used to resize the parent iframe according to the child's content) does not seem to detect changes in height given by the content (in this case the OperatorsTable) changing in size, hence the standard `parentIframe.resize` does not work.

### Solution:
Implement workaround: on pagination size change or on page change (which is problematic if the new page has more or less elements than the previous one) call `parentIframe.sendMessage` to send a 'resize' message to the parentIframe, comunicating the new `document.body.scrollHeight`.

This is a new functionality added to the iFrame component of b2b-portals with [PR #618](https://github.com/pagopa/b2b-portals/pull/618) specifically to address this issue.

### Imperfections:
- Going from a very small to a very high number of elements in a page doesn't align the bottom of the iframe perfectly (testing didn't show any buttons hidden or cut off, so usability shouldn't be compromised)
- Higher pagination sizes seem to make it so that the vertical padding of the page is not accounted for, pushing the title closer to the top of the parent iframe (this is barely noticeable and doesn't compromise usability, but it's still something to note and that could be improved)