### PR TITLE
PN-14492 - Update empty state copy on pickup page

### DIFF
--- a/public/locales/it/pickup.json
+++ b/public/locales/it/pickup.json
@@ -9,7 +9,8 @@
     "description_3": "Cerca i punti di ritiro più vicini a te.",
     "disclaimer": "Al momento puoi cercare solo fra i punti di ritiro presenti in alcuni Comuni italiani: il servizio è in attivazione progressiva su tutto il territorio nazionale.",
     "placeholder": "Cerca per città o per CAP",
-    "empty_state": " Non ci sono ancora punti di ritiro SEND attivi in questa città."
+    "empty_state_1": "Non sembrano essere disponibili punti di ritiro SEND in questa località.",
+    "empty_state_2": "Riprova scrivendo il nome della località per esteso oppure cerca tra i CAP o i Comuni limitrofi."
   },
   "infoblock": {
     "title": "Cosa portare",

--- a/src/pages/[lang]/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7.tsx
+++ b/src/pages/[lang]/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7.tsx
@@ -154,7 +154,8 @@ const RitiroPage: NextPage = () => {
     if (!rowsToSet || rowsToSet.length === 0) {
       return (
         <Box bgcolor="white" p={3} m={3} textAlign="center">
-          <Typography>{t("search.empty_state", { ns: "pickup" })}</Typography>
+          <Typography>{t("search.empty_state_1", { ns: "pickup" })}</Typography>
+          <Typography>{t("search.empty_state_2", { ns: "pickup" })}</Typography>
         </Box>
       );
     }


### PR DESCRIPTION
## How to test
- Run `yarn dev` to start the application
- Navigate to `http://localhost:3000/it/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7/`
- Type something like "Comune X" on searchbar and verify that new copy on empty state is displayed