### PR TITLE
fix(PN-14858): handle mobile map scroll and various fix on list 

### DIFF
--- a/public/locales/de/pickup.json
+++ b/public/locales/de/pickup.json
@@ -29,5 +29,7 @@
     "friday": "Freitag",
     "saturday": "Samstag",
     "sunday": "Sonntag"
-  }
+  },
+  "address-copied": "Adresse in die Zwischenablage kopiert",
+  "map-mobile-help-text": "Benutze zwei Finger, um die Karte zu verschieben"
 }

--- a/public/locales/de/pickup.json
+++ b/public/locales/de/pickup.json
@@ -16,6 +16,7 @@
     "book-alert-title": "Vereinbaren Sie einen Termin beim Steuerhilfezentrum (CAF)",
     "book-alert-description": "Vermeiden Sie Warctezeiten: Vereinbaren Sie einen Termin und erhalten Sie Unterstützung ohne Anstehen.",
     "address": "Adresse",
+    "address-copied": "Adresse in die Zwischenablage kopiert",
     "opening-hours": "Öffnungszeiten",
     "phone-number": "Kontakt",
     "get-directions": "Route anzeigen",
@@ -52,6 +53,5 @@
   "map-loading-error-1": "Fehler beim Laden der Karte.",
   "map-loading-error-2": "Drücken Sie auf „Erneut versuchen“. In der Zwischenzeit können Sie die SEND-Abholstellen in der Liste ansehen.",
   "fetch-csv-error": "Ein Problem ist beim Laden der Ergebnisse aufgetreten.",
-  "address-copied": "Adresse in die Zwischenablage kopiert",
   "map-mobile-help-text": "Benutze zwei Finger, um die Karte zu verschieben"
 }

--- a/public/locales/fr/pickup.json
+++ b/public/locales/fr/pickup.json
@@ -16,6 +16,7 @@
     "book-alert-title": "Prenez rendez-vous au centre d’accompagnement fiscal (CAF)",
     "book-alert-description": "Évitez les files d’attente, prenez rendez-vous et recevez de l’aide sans délai.",
     "address": "Adresse",
+    "address-copied": "Adresse copiée dans le presse-papiers",
     "opening-hours": "Horaires d’ouverture",
     "phone-number": "Contacts",
     "get-directions": "Itinéraire",
@@ -52,6 +53,5 @@
   "map-loading-error-1": "La carte est momentanément indisponible.",
   "map-loading-error-2": "Appuyez sur « Réessayer ». Vous pouvez aussi consulter la liste des Points de retrait SEND.",
   "fetch-csv-error": "Impossible de charger les résultats.",
-  "address-copied": "Adresse copiée dans le presse-papiers",
   "map-mobile-help-text": "Utilisez deux doigts pour déplacer la carte"
 }

--- a/public/locales/fr/pickup.json
+++ b/public/locales/fr/pickup.json
@@ -29,5 +29,7 @@
     "friday": "Vendredi",
     "saturday": "Samedi",
     "sunday": "Dimanche"
-  }
+  },
+  "address-copied": "Adresse copiée dans le presse-papiers",
+  "map-mobile-help-text": "Utilisez deux doigts pour déplacer la carte"
 }

--- a/public/locales/it/pickup.json
+++ b/public/locales/it/pickup.json
@@ -26,7 +26,7 @@
   "book-alert-title": "Prenota il tuo appuntamento al CAF",
   "book-alert-description": "Evita le attese, prenota e ricevi assistenza senza fare la fila.",
   "address": "Indirizzo",
-  "address-copied": "Indirizzo copiato",
+  "address-copied": "Indirizzo copiato negli appunti",
   "opening-hours": "Orari di apertura",
   "days": {
     "monday": "Lunedì",

--- a/public/locales/it/pickup.json
+++ b/public/locales/it/pickup.json
@@ -61,5 +61,6 @@
     "empty-state-title": "Non ci sono corrispondenze da mostrare",
     "empty-state-description": "Controlla i dati inseriti oppure inserisci un altro indirizzo o città.",
     "current-position": "Posizione attuale"
-  }
+  },
+  "map-mobile-help-text": "Utilizza due dita per spostare la mappa"
 }

--- a/public/locales/it/pickup.json
+++ b/public/locales/it/pickup.json
@@ -26,6 +26,7 @@
   "book-alert-title": "Prenota il tuo appuntamento al CAF",
   "book-alert-description": "Evita le attese, prenota e ricevi assistenza senza fare la fila.",
   "address": "Indirizzo",
+  "address-copied": "Indirizzo copiato",
   "opening-hours": "Orari di apertura",
   "days": {
     "monday": "Lunedì",

--- a/src/components/PickupPointsList/index.tsx
+++ b/src/components/PickupPointsList/index.tsx
@@ -151,6 +151,9 @@ function PickupPointsList({
                         width: "fit-content",
                         alignItems: "center",
                         mt: 1,
+                        "&:hover": {
+                          textDecoration: "underline",
+                        },
                       }}
                       onClick={(e: React.MouseEvent) =>
                         handleShowDetails(e, point)

--- a/src/components/PickupPointsList/index.tsx
+++ b/src/components/PickupPointsList/index.tsx
@@ -163,9 +163,18 @@ function PickupPointsList({
               />
 
               {userPosition && (
-                <Box display="flex" alignItems="flex-start" gap={0.5}>
+                <Box
+                  display="flex"
+                  alignItems="flex-start"
+                  gap={0.5}
+                  flexShrink={0}
+                >
                   <Place fontSize="small" sx={{ color: "text.secondary" }} />
-                  <Typography variant="body2" color="text.secondary">
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    whiteSpace="nowrap"
+                  >
                     {`${point.distance?.toFixed(1) || "-"} km`}
                   </Typography>
                 </Box>

--- a/src/components/PickupPointsList/index.tsx
+++ b/src/components/PickupPointsList/index.tsx
@@ -1,5 +1,5 @@
 import { Place, Refresh } from "@mui/icons-material";
-import { Box, List, ListItem, Paper, Stack, Typography } from "@mui/material";
+import { Box, List, ListItem, ListItemText, Typography } from "@mui/material";
 import { ButtonNaked } from "@pagopa/mui-italia";
 import { sortPointsByDistance } from "@utils/map";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -119,87 +119,73 @@ function PickupPointsList({
             <ListItem
               key={`${point.denomination}-${point.id}-${index}`}
               onClick={() => onSelectPoint(point)}
+              alignItems="flex-start"
               sx={{
                 border: isSelected ? "2px solid" : "1px solid",
                 borderColor: isSelected ? "#2185E9" : "divider",
                 borderRadius: "8px",
                 my: 2,
-                p: 0,
+                p: 3,
                 cursor: "pointer",
+                backgroundColor: isSelected ? "#0073E614" : "transparent",
+                "&:hover": {
+                  backgroundColor: "#0073e61f",
+                },
               }}
             >
-              <Stack
-                component={Paper}
-                width="100%"
-                sx={{
-                  p: 3,
-                  borderRadius: "8px",
-                  backgroundColor: isSelected ? "#0073E614" : "transparent",
-                  "&:hover": {
-                    backgroundColor: "#0073e61f",
-                  },
-                }}
-              >
-                <Box
-                  display="flex"
-                  justifyContent="space-between"
-                  alignItems="flex-start"
-                >
-                  <Box mb={1}>
-                    <Typography variant="body1" fontWeight={600}>
-                      {point.denomination}
-                    </Typography>
-                    <Typography variant="body2" fontSize="14px">
+              <ListItemText
+                primary={
+                  <Typography variant="body1" fontWeight={600}>
+                    {point.denomination}
+                  </Typography>
+                }
+                secondary={
+                  <>
+                    <Typography variant="body2" fontSize="14px" component="div">
                       {point.normalizedAddress}
                     </Typography>
-                  </Box>
-
-                  {userPosition && (
-                    <Stack
-                      direction="row"
-                      spacing={1}
-                      alignItems="center"
-                      justifyContent="flex-end"
+                    <ButtonNaked
+                      color="primary"
+                      sx={{
+                        justifyContent: "flex-start",
+                        width: "fit-content",
+                        alignItems: "center",
+                        mt: 1,
+                      }}
+                      onClick={(e: React.MouseEvent) =>
+                        handleShowDetails(e, point)
+                      }
                     >
-                      <Place
-                        fontSize="small"
-                        sx={{ color: "text.secondary" }}
-                      />
-                      <Typography variant="body2" color="text.secondary">
-                        km {point.distance?.toFixed(1) || "-"}
-                      </Typography>
-                    </Stack>
-                  )}
-                </Box>
+                      {t("show-details")}
+                    </ButtonNaked>
+                  </>
+                }
+              />
 
-                <ButtonNaked
-                  color="primary"
-                  sx={{
-                    justifyContent: "flex-start",
-                    width: "fit-content",
-                    alignItems: "center",
-                  }}
-                  onClick={(e: React.MouseEvent) => handleShowDetails(e, point)}
-                >
-                  {t("show-details")}
-                </ButtonNaked>
-              </Stack>
+              {userPosition && (
+                <Box display="flex" alignItems="flex-start" gap={0.5}>
+                  <Place fontSize="small" sx={{ color: "text.secondary" }} />
+                  <Typography variant="body2" color="text.secondary">
+                    {`${point.distance?.toFixed(1) || "-"} km`}
+                  </Typography>
+                </Box>
+              )}
             </ListItem>
           );
         })}
-
-        {visibleItems.length < sortedItems.length && (
-          <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
-            <ButtonNaked
-              color="primary"
-              onClick={handleShowMore}
-              startIcon={<Refresh />}
-            >
-              {t("show-more")}
-            </ButtonNaked>
-          </Box>
-        )}
       </List>
+
+      {visibleItems.length < sortedItems.length && (
+        <Box sx={{ display: "flex", justifyContent: "center", my: 2 }}>
+          <ButtonNaked
+            color="primary"
+            onClick={handleShowMore}
+            startIcon={<Refresh />}
+          >
+            {t("show-more")}
+          </ButtonNaked>
+        </Box>
+      )}
     </>
   );
 }

--- a/src/components/PickupPointsList/index.tsx
+++ b/src/components/PickupPointsList/index.tsx
@@ -104,7 +104,7 @@ function PickupPointsList({
       <List
         ref={listContainerRef}
         sx={{
-          maxHeight: "800px",
+          maxHeight: { xs: "100%", lg: "800px" },
           overflowY: { xs: "none", lg: "auto" },
           p: 0,
           mt: 2,

--- a/src/components/PickupPointsMap/index.tsx
+++ b/src/components/PickupPointsMap/index.tsx
@@ -11,6 +11,7 @@ import ErrorBox from "../ErrorBox";
 import Clusters from "./Clusters";
 import MapControls from "./MapControls";
 import UserPositionController from "./UserPositionController";
+import { useIsMobile } from "src/hook/useIsMobile";
 
 type Props = {
   points: Array<RaddOperator>;
@@ -29,6 +30,7 @@ const PickupPointsMap: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation(["pickup"]);
   const mapRef = useRef<MapRef>(null);
+  const isMobile = useIsMobile();
   const [mapError, setMapError] = useState(false);
   const { CLOUDFRONT_MAP_URL } = useConfig();
   const [imagesLoaded, setImagesLoaded] = useState(false);
@@ -126,6 +128,10 @@ const PickupPointsMap: React.FC<Props> = ({
       onLoad={handleLoad}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      cooperativeGestures={!!isMobile}
+      locale={{
+        "CooperativeGesturesHandler.MobileHelpText": t("map-mobile-help-text"),
+      }}
       style={{ height: "100%", width: "100%", position: "relative" }}
     >
       <UserPositionController points={points} />

--- a/src/components/Ritiro/PickupPointsInfoDrawer.tsx
+++ b/src/components/Ritiro/PickupPointsInfoDrawer.tsx
@@ -150,7 +150,7 @@ const PickupPointsInfoDrawer: React.FC<Props> = ({
                   </Typography>
                   <CopyToClipboardButton
                     value={point.normalizedAddress}
-                    tooltipTitle={t("address-copied")}
+                    tooltipTitle={t("drawer.address-copied")}
                   />
                 </Stack>
               </Stack>

--- a/src/components/Ritiro/PickupPointsInfoDrawer.tsx
+++ b/src/components/Ritiro/PickupPointsInfoDrawer.tsx
@@ -148,7 +148,10 @@ const PickupPointsInfoDrawer: React.FC<Props> = ({
                   >
                     {point.normalizedAddress}
                   </Typography>
-                  <CopyToClipboardButton value={point.normalizedAddress} />
+                  <CopyToClipboardButton
+                    value={point.normalizedAddress}
+                    tooltipTitle={t("address-copied")}
+                  />
                 </Stack>
               </Stack>
 

--- a/src/pages/[lang]/mappa-punti-di-ritiro.tsx
+++ b/src/pages/[lang]/mappa-punti-di-ritiro.tsx
@@ -158,7 +158,7 @@ const PickupPointsPage: NextPage = () => {
               },
             }}
           >
-            <Box sx={{ width: "100%", height: "1000px" }}>
+            <Box sx={{ width: "100%", height: { xs: "500px", md: "1000px" } }}>
               <PickupPointsMap
                 points={points}
                 selectedPoint={selectedPoint}
@@ -173,7 +173,7 @@ const PickupPointsPage: NextPage = () => {
         <ErrorBox
           handleRetry={getData}
           retryLabel={t("retry-cta")}
-          sx={{ mt: 4, mb: 2, height: "1000px" }}
+          sx={{ mt: 4, mb: 2, height: { xs: "500px", md: "1000px" } }}
         >
           <Typography variant="body2" color="text.secondary" fontWeight={600}>
             {t("fetch-csv-error")}

--- a/src/pages/[lang]/mappa-punti-di-ritiro.tsx
+++ b/src/pages/[lang]/mappa-punti-di-ritiro.tsx
@@ -91,7 +91,6 @@ const PickupPointsPage: NextPage = () => {
         src="/iframe-resizer/child/index.umd.js"
         type="text/javascript"
         id="iframe-resizer-child"
-        strategy="beforeInteractive"
       />
 
       {!fetchError ? (


### PR DESCRIPTION
## How to test
- Check that on mobile the map requires two fingers to navigate (also verify that this behaviour is not required on desktop)
- Resize the screen and check that the distance text never wraps
- On "Mostra dettagli" button hover it should underline the text
- On copy address it should show successful message