### PR TITLE
fix(PN-15512): remove strategy from iframe-resizer script

### DIFF
--- a/src/pages/[lang]/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7.tsx
+++ b/src/pages/[lang]/punti-di-ritiro-2a89b635-66f8-458a-a59b-8fb4146cd9d7.tsx
@@ -197,7 +197,6 @@ const RitiroPage: NextPage = () => {
         src="/iframe-resizer/child/index.umd.js"
         type="text/javascript"
         id="iframe-resizer-child"
-        strategy="beforeInteractive"
       />
 
       <Stack

--- a/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
+++ b/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
@@ -69,7 +69,6 @@ const SendInNumbers: NextPage = () => {
         src="/iframe-resizer/child/index.umd.js"
         type="text/javascript"
         id="iframe-resizer-child"
-        strategy="beforeInteractive"
       />
 
       <Box mt={8}>


### PR DESCRIPTION
This PR resolves [PN-15512](https://pagopa.atlassian.net/browse/PN-15512) to ensure that `iframe-resizer` works correctly on the `SEND in Numeri` page.

[PN-15512]: https://pagopa.atlassian.net/browse/PN-15512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ