### PR TITLE
fix(PN-15514): keep sorted list by searched address when change tab on mobile

### DIFF
--- a/src/components/PickupPointsAutocomplete/index.tsx
+++ b/src/components/PickupPointsAutocomplete/index.tsx
@@ -5,7 +5,7 @@ import { visuallyHidden } from "@mui/utils";
 import { useConfig } from "src/context/config-context";
 import useCurrentPosition from "src/hook/useCurrentPosition";
 import { useTranslation } from "src/hook/useTranslation";
-import { AddressResult, Coordinates } from "src/model";
+import { AddressResult, Coordinates, RaddOperator } from "src/model";
 import MuiItaliaAutocomplete from "../MuiItaliaAutocomplete";
 import AddressItem from "./AddressItem";
 import EmptyState from "./EmptyState";
@@ -17,6 +17,7 @@ const MIN_QUERY_LENGTH = 3;
 
 interface Props {
   setSearchCoordinates: (coordinates: Coordinates) => void;
+  setSelectedPoint: (point: RaddOperator | null) => void;
 }
 
 const createApiUrl = (endpoint: string, params: Record<string, string>) => {
@@ -29,6 +30,7 @@ const createApiUrl = (endpoint: string, params: Record<string, string>) => {
 
 const PickupPointsAutocomplete: React.FC<Props> = ({
   setSearchCoordinates,
+  setSelectedPoint,
 }) => {
   const { t } = useTranslation(["pickup"]);
   const { userPosition } = useCurrentPosition();
@@ -76,6 +78,7 @@ const PickupPointsAutocomplete: React.FC<Props> = ({
 
       const coordinates: Coordinates = await response.json();
       setSearchCoordinates(coordinates);
+      setSelectedPoint(null);
     } catch (error) {
       setFetchError(true);
     }

--- a/src/components/PickupPointsList/index.tsx
+++ b/src/components/PickupPointsList/index.tsx
@@ -86,7 +86,7 @@ function PickupPointsList({
     }
 
     if (!selectedPoint) {
-      setCustomSortTarget(null);
+      setCustomSortTarget(searchCoordinates || null);
       return;
     }
 
@@ -98,13 +98,7 @@ function PickupPointsList({
     }
 
     scrollToItem(selectedPoint);
-  }, [selectedPoint, isVisible]);
-
-  useEffect(() => {
-    if (searchCoordinates) {
-      setCustomSortTarget(searchCoordinates);
-    }
-  }, [searchCoordinates]);
+  }, [selectedPoint, searchCoordinates, isVisible]);
 
   if (!points || points.length === 0) {
     return <Skeletons />;

--- a/src/pages/[lang]/mappa-punti-di-ritiro.tsx
+++ b/src/pages/[lang]/mappa-punti-di-ritiro.tsx
@@ -136,6 +136,7 @@ const PickupPointsPage: NextPage = () => {
 
             <PickupPointsAutocomplete
               setSearchCoordinates={setSearchCoordinates}
+              setSelectedPoint={setSelectedPoint}
             />
 
             <Box sx={{ display: { xs: "flex", md: "none" }, my: 3 }}>


### PR DESCRIPTION
## How to test

1. Go to the Mappa Punti di Ritiro page
2. Switch to mobile view
3. Use the autocomplete search to look up a locality and verify that the list is sorted by distance from the searched location
4. Switch to map view and confirm that the map centers on the searched address
5. Return to list view and ensure the list is still sorted by distance from the searched address


Added logic to clear the selected pickup point when a new address is searched.  
This ensures the list is always sorted by the most recently searched address.