### PR TITLE
fix(PN-15552): set fixed height to pickup points modal and add missing translations

### DIFF
--- a/public/locales/de/pickup.json
+++ b/public/locales/de/pickup.json
@@ -14,11 +14,12 @@
   "how-it-works": "Wie es funktioniert",
   "drawer": {
     "book-alert-title": "Vereinbaren Sie einen Termin beim Steuerhilfezentrum (CAF)",
+    "required-book-alert-title": "Dieses Steuerhilfezentrum (CAF) empfängt nur nach Terminvereinbarung.",
     "book-alert-description": "Vermeiden Sie Warctezeiten: Vereinbaren Sie einen Termin und erhalten Sie Unterstützung ohne Anstehen.",
     "address": "Adresse",
     "address-copied": "Adresse in die Zwischenablage kopiert",
     "opening-hours": "Öffnungszeiten",
-    "phone-number": "Kontakt",
+    "contacts": "Kontakt",
     "get-directions": "Route anzeigen",
     "copy-informations": "Informationen kopieren",
     "reservation-call": "Zum Buchen rufen Sie die",
@@ -30,7 +31,10 @@
       "friday": "Freitag",
       "saturday": "Samstag",
       "sunday": "Sonntag"
-    }
+    },
+    "or": "oder",
+    "location-id": "ID der Geschäftsstelle des Steuerhilfezentrums (CAF)",
+    "external-codes": "Codes der Geschäftsstelle"
   },
   "show-more": "Weitere Ergebnisse suchen",
   "show-details": "Details anzeigen",

--- a/public/locales/fr/pickup.json
+++ b/public/locales/fr/pickup.json
@@ -14,11 +14,12 @@
   "how-it-works": "En savoir plus",
   "drawer": {
     "book-alert-title": "Prenez rendez-vous au centre d’accompagnement fiscal (CAF)",
+    "required-book-alert-title": "Ce centre d’accompagnement fiscal (CAF) reçoit uniquement sur rendez-vous.",
     "book-alert-description": "Évitez les files d’attente, prenez rendez-vous et recevez de l’aide sans délai.",
     "address": "Adresse",
     "address-copied": "Adresse copiée dans le presse-papiers",
     "opening-hours": "Horaires d’ouverture",
-    "phone-number": "Contacts",
+    "contacts": "Contacts",
     "get-directions": "Itinéraire",
     "copy-informations": "Copier les informations",
     "reservation-call": "Pour réserver, appelez le",
@@ -30,7 +31,10 @@
       "friday": "Vendredi",
       "saturday": "Samedi",
       "sunday": "Dimanche"
-    }
+    },
+    "or": "ou",
+    "location-id": "Identifiant de l’agence du centre d’accompagnement fiscal (CAF)",
+    "external-codes": "Codes associés à l’agence"
   },
   "show-more": "Plus de résultats",
   "show-details": "Voir les détails",

--- a/public/locales/it/pickup.json
+++ b/public/locales/it/pickup.json
@@ -32,7 +32,10 @@
       "friday": "Venerdì",
       "saturday": "Sabato",
       "sunday": "Domenica"
-    }
+    },
+    "or": "o",
+    "location-id": "ID sede CAF",
+    "external-codes": "Codici associati alla sede"
   },
   "show-more": "Carica altri risultati",
   "show-details": "Mostra dettagli",

--- a/src/components/PickupPointsInfoDialog/index.tsx
+++ b/src/components/PickupPointsInfoDialog/index.tsx
@@ -73,13 +73,15 @@ const PickupPointsInfoDialog: React.FC<Props> = ({
     }
 
     sections.push(
-      `${t("drawer.reservation-call")} ${point.contacts.split("_").join(" o ")}`
+      `${t("drawer.reservation-call")} ${point.contacts
+        .split("_")
+        .join(` ${t("drawer.or")} `)}`
     );
 
     sections.push(
       [
-        `ID: ${point.locationId}`,
-        `Codice Esterno: ${point.external_codes}`,
+        `${t("drawer.location-id")}: ${point.locationId}`,
+        `${t("drawer.external-codes")}: ${point.external_codes}`,
       ].join("\n")
     );
 
@@ -106,7 +108,7 @@ const PickupPointsInfoDialog: React.FC<Props> = ({
             xs: "auto",
             md: "600px",
           },
-          maxHeight: "80vh",
+          maxHeight: { xs: "550px", md: "650px" },
           display: "flex",
           flexDirection: "column",
         },


### PR DESCRIPTION
## How to test
- Check that the modal on both desktop and mobile does not overflow the screen size.
- Open the details of a CAF, click on `Copia Informazioni`, and verify that all labels are translated (also check for `fr` and `de` by editing the path parameter).
