### PR TITLE
feat(BPPSF-17): deploy banner + new kpis

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "5.11.0",
     "@mui/lab": "5.0.0-alpha.119",
     "@mui/material": "5.11.8",
-    "@pagopa/mui-italia": "^2.4.1",
+    "@pagopa/mui-italia": "2.5.1-RC.0",
     "maplibre-gl": "^5.5.0",
     "next": "^15.5.18",
     "papaparse": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "5.11.0",
     "@mui/lab": "5.0.0-alpha.119",
     "@mui/material": "5.11.8",
-    "@pagopa/mui-italia": "2.5.1-RC.0",
+    "@pagopa/mui-italia": "2.6.0-RC.3",
     "maplibre-gl": "^5.5.0",
     "next": "^15.5.18",
     "papaparse": "^5.4.1",

--- a/public/locales/de/numeri.json
+++ b/public/locales/de/numeri.json
@@ -9,7 +9,9 @@
     "description_3": ", die täglich aktualisiert werden.",
     "last_update": "Letzte Aktualisierung",
     "alert": "Die Daten sind auf dati.gov.it verfügbar",
-    "website": "Zu den Daten"
+    "website": "Zu den Daten",
+    "maintenance_alert_title": "Achtung",
+    "maintenance_alert": "Es findet eine geplante Wartung statt, die zu Verzögerungen bei der Verfügbarkeit der Daten im Dashboard und der Open Data führen kann. Bitte beachten Sie das auf dieser Seite angegebene Datum, um die letzte verfügbare Aktualisierung zu überprüfen. Die Aktualisierungen werden nach Abschluss der Wartung regelmäßig fortgesetzt."
   },
   "total": "Alle",
   "sent_notifications": {

--- a/public/locales/de/numeri.json
+++ b/public/locales/de/numeri.json
@@ -10,8 +10,8 @@
     "last_update": "Letzte Aktualisierung",
     "alert": "Die Daten sind auf dati.gov.it verfügbar",
     "website": "Zu den Daten",
-    "maintenance_alert_title": "Achtung",
-    "maintenance_alert": "Es findet eine geplante Wartung statt, die zu Verzögerungen bei der Verfügbarkeit der Daten im Dashboard und der Open Data führen kann. Bitte beachten Sie das auf dieser Seite angegebene Datum, um die letzte verfügbare Aktualisierung zu überprüfen. Die Aktualisierungen werden nach Abschluss der Wartung regelmäßig fortgesetzt."
+    "maintenance_alert_title": "Wartungsarbeiten im Gange",
+    "maintenance_alert": "Aufgrund einer geplanten Wartung kann es zu Verzögerungen bei der Aktualisierung der Daten im Dashboard und im Open-Data-Bereich kommen. Bitte beachten Sie das auf dieser Seite angegebene Datum für den Stand der letzten Aktualisierung. Nach Abschluss der Wartung werden die Daten wieder regelmäßig aktualisiert."
   },
   "total": "Alle",
   "sent_notifications": {
@@ -67,8 +67,10 @@
   },
 
   "avvisi": {
-    "title": "Versandte Hinweise",
-    "description": "Entwicklung der Anzahl der versandten Hinweise, d.h. Nachrichten, die darüber informieren, wenn eine SEND-Benachrichtigung zum Lesen vorliegt, versandt über die IO-App, E-Mail oder SMS.",
+    "title": "Versandte Höflichkeitshinweise",
+    "description": "Verteilung der Anzahl der versandten Höflichkeitshinweise über die IO-App, E-Mail oder SMS zur Information der Empfänger über das Vorhandensein einer SEND-Benachrichtigung zum Lesen.",
+    "note": "Höflichkeitshinweise informieren die Empfänger über das Vorhandensein einer neuen SEND-Benachrichtigung zum Lesen. Sie können über die IO-App, E-Mail oder SMS gesendet werden, wenn der Empfänger den Dienst auf IO aktiviert oder seine Kontaktdaten auf SEND konfiguriert hat. Weitere Details sind verfügbar unter ",
+    "note_link": "diesem Link",
     "total": {
       "title": "Gesamtzahl der versandten Hinweise",
       "description": "Gesamtzahl der im betrachteten Bezugszeitraum versandten Hinweise.",
@@ -114,6 +116,12 @@
         "percentage": "Anteil der Gemeinden an der Gesamtzahl der Gemeinden in der Region"
       }
     }
+  },
+
+  "categorie_enti": {
+    "title": "Wichtigste Kategorien sendender Institutionen",
+    "description": "Anzahl der von Institutionen versendeten SEND-Benachrichtigungen, aufgeteilt nach Makro-Kategorien.",
+    "note_1": "Die Darstellung umfasst Institutionen mit einer Anzahl von versandten Benachrichtigungen von 5 oder mehr."
   },
 
   "atti": {

--- a/public/locales/en/numeri.json
+++ b/public/locales/en/numeri.json
@@ -9,7 +9,9 @@
     "description_3": ", updated daily.",
     "last_update": "Last update",
     "alert": "Data is available on dati.gov.it",
-    "website": "See data"
+    "website": "See data",
+    "maintenance_alert_title": "Warning",
+    "maintenance_alert": "Scheduled maintenance is in progress and may cause delays in the availability of dashboard and open data. Please refer to the date shown on this page to check the latest available update. Updates will resume regularly once the maintenance is complete."
   },
   "total": "All",
   "sent_notifications": {

--- a/public/locales/en/numeri.json
+++ b/public/locales/en/numeri.json
@@ -10,8 +10,8 @@
     "last_update": "Last update",
     "alert": "Data is available on dati.gov.it",
     "website": "See data",
-    "maintenance_alert_title": "Warning",
-    "maintenance_alert": "Scheduled maintenance is in progress and may cause delays in the availability of dashboard and open data. Please refer to the date shown on this page to check the latest available update. Updates will resume regularly once the maintenance is complete."
+    "maintenance_alert_title": "Maintenance in progress",
+    "maintenance_alert": "Scheduled maintenance is in progress and may delay data updates on the dashboard and in open datasets. Please refer to the date shown on this page to check the latest update. Regular updates will resume once maintenance is complete."
   },
   "total": "All",
   "sent_notifications": {
@@ -67,8 +67,10 @@
   },
 
   "avvisi": {
-    "title": "Notices sent",
-    "description": "Trend of the number of notices sent, i.e., messages informing when there is a SEND notification to read, sent via IO App, e-mail or SMS.",
+    "title": "Courtesy notices sent",
+    "description": "Distribution of the number of courtesy notices sent via the IO app, e-mail or SMS to inform recipients of the presence of a SEND notification to read.",
+    "note": "Courtesy notices inform recipients of the presence of a new SEND notification to read. They can be sent via the IO app, e-mail or SMS if the recipient has activated the service on IO or configured their contact details on SEND. More details are available at ",
+    "note_link": "this link",
     "total": {
       "title": "Total notices sent",
       "description": "Total notices sent in the reference period considered.",
@@ -114,6 +116,12 @@
         "percentage": "Percentage of municipalities compared to the total number of municipalities in the region"
       }
     }
+  },
+
+  "categorie_enti": {
+    "title": "Main categories of sending institutions",
+    "description": "Number of SEND notifications sent by institutions, broken down by macro category.",
+    "note_1": "The representation includes institutions with a number of sent notifications equal to or greater than 5."
   },
 
   "atti": {

--- a/public/locales/fr/numeri.json
+++ b/public/locales/fr/numeri.json
@@ -9,7 +9,9 @@
     "description_3": ", mises à jour quotidiennement.",
     "last_update": "Dernière mise à jour",
     "alert": "Les données sont disponibles sur dati.gov.it",
-    "website": "Voir les données"
+    "website": "Voir les données",
+    "maintenance_alert_title": "Attention",
+    "maintenance_alert": "Une maintenance programmée est en cours et pourrait entraîner des retards dans la disponibilité des données du tableau de bord et des données ouvertes. Veuillez vous référer à la date indiquée sur cette page pour vérifier la dernière mise à jour disponible. Les mises à jour reprendront normalement à la fin de l'intervention."
   },
   "total": "Tous",
   "sent_notifications": {

--- a/public/locales/fr/numeri.json
+++ b/public/locales/fr/numeri.json
@@ -10,8 +10,8 @@
     "last_update": "Dernière mise à jour",
     "alert": "Les données sont disponibles sur dati.gov.it",
     "website": "Voir les données",
-    "maintenance_alert_title": "Attention",
-    "maintenance_alert": "Une maintenance programmée est en cours et pourrait entraîner des retards dans la disponibilité des données du tableau de bord et des données ouvertes. Veuillez vous référer à la date indiquée sur cette page pour vérifier la dernière mise à jour disponible. Les mises à jour reprendront normalement à la fin de l'intervention."
+    "maintenance_alert_title": "Maintenance en cours",
+    "maintenance_alert": "Une maintenance programmée est en cours. Elle pourrait entraîner des retards dans la mise à jour des données du tableau de bord et des données ouvertes. Veuillez vous référer à la date indiquée sur cette page pour vérifier la dernière mise à jour disponible. Les mises à jour reprendront normalement à la fin de l'intervention."
   },
   "total": "Tous",
   "sent_notifications": {
@@ -67,8 +67,10 @@
   },
 
   "avvisi": {
-    "title": "Avis envoyés",
-    "description": "Évolution du nombre d'avis envoyés, c'est-à-dire de messages informant qu'il y a une notification SEND à lire, envoyés via l'app IO, par e-mail ou par SMS.",
+    "title": "Avis de courtoisie envoyés",
+    "description": "Distribution du nombre d'avis de courtoisie envoyés via l'app IO, par e-mail ou par SMS pour informer les destinataires de la présence d'une notification SEND à lire.",
+    "note": "Les avis de courtoisie informent les destinataires de la présence d'une nouvelle notification SEND à lire. Ils peuvent être envoyés via l'app IO, par e-mail ou par SMS si le destinataire a activé le service sur IO ou configuré ses coordonnées sur SEND. Plus de détails sont disponibles à ",
+    "note_link": "ce lien",
     "total": {
       "title": "Total des avis envoyés",
       "description": "Total des avis envoyés au cours de la période de référence considérée.",
@@ -114,6 +116,12 @@
         "percentage": "Pourcentage de communes par rapport au nombre total de communes dans la région"
       }
     }
+  },
+
+  "categorie_enti": {
+    "title": "Principales catégories d'organismes émetteurs",
+    "description": "Nombre de notifications SEND envoyées par les organismes, réparties par macro-catégorie.",
+    "note_1": "La représentation inclut les organismes avec un nombre de notifications envoyées égal ou supérieur à 5."
   },
 
   "atti": {

--- a/public/locales/it/numeri.json
+++ b/public/locales/it/numeri.json
@@ -9,7 +9,9 @@
     "description_3": ", aggiornati quotidianamente.",
     "last_update": "Ultimo aggiornamento",
     "alert": "I dati sono disponibili su dati.gov.it",
-    "website": "Vai al sito"
+    "website": "Vai al sito",
+    "maintenance_alert_title": "Attenzione",
+    "maintenance_alert": "È in corso una manutenzione programmata che potrebbe comportare dei ritardi nella disponibilità dei dati su dashboard e open data. Fai riferimento alla data indicata su questa pagina per verificare l'ultimo aggiornamento disponibile. Gli aggiornamenti riprenderanno regolarmente al termine dell'intervento."
   },
   "total": "Tutti",
   "sent_notifications": {

--- a/public/locales/it/numeri.json
+++ b/public/locales/it/numeri.json
@@ -10,7 +10,7 @@
     "last_update": "Ultimo aggiornamento",
     "alert": "I dati sono disponibili su dati.gov.it",
     "website": "Vai al sito",
-    "maintenance_alert_title": "Attenzione",
+    "maintenance_alert_title": "Manutenzione in corso",
     "maintenance_alert": "È in corso una manutenzione programmata che potrebbe comportare dei ritardi nella disponibilità dei dati su dashboard e open data. Fai riferimento alla data indicata su questa pagina per verificare l'ultimo aggiornamento disponibile. Gli aggiornamenti riprenderanno regolarmente al termine dell'intervento."
   },
   "total": "Tutti",
@@ -67,8 +67,10 @@
   },
 
   "avvisi": {
-    "title": "Avvisi inviati",
-    "description": "Andamento del numero di avvisi inviati, cioè messaggi che informano quando c’è una notifica SEND da leggere, inviati tramite App IO, e-mail o SMS.",
+    "title": "Avvisi di cortesia inviati",
+    "description": "Distribuzione del numero di avvisi di cortesia inviati tramite l’app IO, e-mail o SMS per informare i destinatari della presenza di una notifica SEND da leggere.",
+    "note": "Gli avvisi di cortesia informano i destinatari della presenza di una nuova notifica SEND da leggere. Possono essere inviati tramite l’app IO, e-mail o SMS se il destinatario ha attivato il servizio su IO o configurato i propri recapiti su SEND. Maggiori dettagli sono disponibili a ",
+    "note_link": "questo link",
     "total": {
       "title": "Totale avvisi inviati",
       "description": "Totale degli avvisi inviati nel periodo di riferimento considerato.",
@@ -85,7 +87,7 @@
 
   "entities": {
     "title": "Enti su SEND",
-    "description": "Enti aderenti che hanno inviato almeno una notifica SEND dall’avvio del servizio.",
+    "description": "Enti aderenti che hanno inviato almeno una notifica SEND.",
     "active": {
       "total": {
         "title": "Totale enti su SEND",
@@ -114,6 +116,12 @@
         "percentage": "Percentuale comuni rispetto al totale dei comuni per regione"
       }
     }
+  },
+
+  "categorie_enti": {
+    "title": "Principali categorie di enti mittenti",
+    "description": "Numero di notifiche SEND inviate dagli enti mittenti, suddivise per macro categorie.",
+    "note_1": "La rappresentazione include gli enti mittenti con un numero di notifiche inviate uguale o superiore a 5."
   },
 
   "atti": {

--- a/public/locales/sl/numeri.json
+++ b/public/locales/sl/numeri.json
@@ -9,7 +9,9 @@
     "description_3": ", ki se dnevno posodabljajo.",
     "last_update": "Zadnja posodobitev",
     "alert": "Podatki so na voljo na dati.gov.it",
-    "website": "Poglej podatke"
+    "website": "Poglej podatke",
+    "maintenance_alert_title": "Pozor",
+    "maintenance_alert": "Poteka načrtovano vzdrževanje, ki lahko povzroči zamude pri razpoložljivosti podatkov na nadzorni plošči in odprtih podatkov. Za preverjanje zadnje razpoložljive posodobitve si oglejte datum, naveden na tej strani. Posodobitve se bodo redno nadaljevale po zaključku vzdrževanja."
   },
   "total": "Skupno",
   "sent_notifications": {

--- a/public/locales/sl/numeri.json
+++ b/public/locales/sl/numeri.json
@@ -67,8 +67,10 @@
   },
 
   "avvisi": {
-    "title": "Poslana opozorila",
-    "description": "Trend števila poslanih opozoril, tj. sporočil, ki obveščajo, ko je na voljo obvestilo SEND za branje, poslanih prek aplikacije IO, e-pošte ali SMS.",
+    "title": "Poslana vljudnostna opozorila",
+    "description": "Porazdelitev števila vljudnostnih opozoril, poslanih prek aplikacije IO, e-pošte ali SMS za obveščanje prejemnikov o prisotnosti obvestila SEND za branje.",
+    "note": "Vljudnostna opozorila obveščajo prejemnike o prisotnosti novega obvestila SEND za branje. Poslana so lahko prek aplikacije IO, e-pošte ali SMS, če je prejemnik aktiviral storitev na IO ali konfiguriral svoje kontaktne podatke na SEND. Več podrobnosti je na voljo na ",
+    "note_link": "tej povezavi",
     "total": {
       "title": "Skupno poslana opozorila",
       "description": "Skupno število opozoril, poslanih v obravnavanem referenčnem obdobju.",
@@ -114,6 +116,12 @@
         "percentage": "Odstotek občin glede na skupno število občin na regijo."
       }
     }
+  },
+
+  "categorie_enti": {
+    "title": "Glavne kategorije pošiljateljev",
+    "description": "Število obvestil SEND, ki so jih poslale institucije, razčlenjenih po makro kategorijah.",
+    "note_1": "Prikaz vključuje institucije s številom poslanih obvestil, enakim ali večjim od 5."
   },
 
   "atti": {

--- a/src/components/Numeri/assets/data/top-categorie-enti.vl.json
+++ b/src/components/Numeri/assets/data/top-categorie-enti.vl.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+  "padding": {
+    "right": 5
+  },
+  "data": {
+    "url": "https://pdnd-prod-dl-1-public-data.s3.eu-central-1.amazonaws.com/dashboard/send/dashboard-send-sezione2.json",
+    "format": { "property": "notif_enti_category" }
+  },
+  "params": [
+    { "name": "year", "value": null }
+  ],
+  "transform": [
+    {
+      "filter": "year === year(datum.year) || year === datum.year"
+    }
+  ],
+  "height": 560,
+  "width": "container",
+  "encoding": {
+    "y": {
+      "field": "categoria_ente",
+      "sort": { "field": "ranking", "order": "ascending" },
+      "scale": { "padding": 0 },
+      "axis": {
+        "domain": false,
+        "labelAlign": "left",
+        "labelLimit": 0,
+        "labelOffset": -20,
+        "labelPadding": 0,
+        "ticks": false
+      }
+    }
+  },
+  "layer": [
+    {
+      "mark": {
+        "type": "bar",
+        "height": 19,
+        "color": "#0B3EE3",
+        "cornerRadius": 5
+      },
+      "encoding": {
+        "x": {
+          "field": "num_iun",
+          "type": "quantitative",
+          "aggregate": "sum",
+          "axis": { "format": "~s", "gridDash": [21, 35], "gridDashOffset": 38 }
+        }
+      }
+    },
+    {
+      "mark": { "type": "bar", "tooltip": true, "color": "transparent" },
+      "encoding": {
+        "tooltip": [
+          { "field": "categoria_ente", "title": "Categoria ente" },
+          {
+            "field": "num_iun",
+            "aggregate": "sum",
+            "title": "Notifiche",
+            "format": ",d"
+          }
+        ]
+      }
+    },
+    {
+      "mark": {
+        "type": "text",
+        "align": "left",
+        "baseline": "middle",
+        "dx": 2,
+        "dy": 0
+      },
+      "encoding": {
+        "x": {
+          "field": "num_iun",
+          "type": "quantitative",
+          "aggregate": "sum"
+        },
+        "text": {
+          "field": "num_iun",
+          "type": "quantitative",
+          "aggregate": "sum",
+          "format": ",d"
+        }
+      }
+    }
+  ]
+}

--- a/src/components/Numeri/components/KpiEntitiesPerc.tsx
+++ b/src/components/Numeri/components/KpiEntitiesPerc.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const isSceneText = (
-  item: VegaScene | VegaSceneGroup | SceneText,
+  item: VegaScene | VegaSceneGroup | SceneText
 ): item is SceneText => "text" in item;
 
 const KpiEntitiesPerc = ({ spec, children }: Props) => {

--- a/src/components/Numeri/components/NotificationsTypes.tsx
+++ b/src/components/Numeri/components/NotificationsTypes.tsx
@@ -1,4 +1,4 @@
-import { Box, MenuItem, Select, Stack, Typography } from "@mui/material";
+import { MenuItem, Select, Stack, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 import { TopLevelSpec } from "vega-lite";
 import { useTranslation } from "../../../hook/useTranslation";
@@ -8,7 +8,6 @@ import { dashboardColors } from "../shared/colors";
 import { url } from "../shared/constants";
 import type { SectionTwoData } from "../shared/jsonTypes";
 import CardText from "./CardText";
-import KpiCard from "./KpiCard";
 import NotificationsTypesChart from "./NotificationsTypesChart";
 
 function generateTag(str: string | null): string {
@@ -116,9 +115,7 @@ const NotificationsTypes = ({ selYear }: Props) => {
   }));
 
   return (
-    <Box sx={{ height: "49rem" }}>
-      <KpiCard>
-        <Stack direction="column" spacing={2}>
+    <Stack direction="column" spacing={2}>
           <Stack direction="row" spacing={2} alignItems="center">
             <CardText>
               {t("notification_types.main_scopes.title", { ns: "numeri" })}
@@ -159,7 +156,15 @@ const NotificationsTypes = ({ selYear }: Props) => {
               color: dashboardColors.get("grey-650"),
               fontSize: "0.875rem",
               lineHeight: "1.125rem",
-              py: "1rem"
+            }}
+          >
+            {t("notification_types.main_scopes.note_2", { ns: "numeri" })}
+          </Typography>
+          <Typography
+            sx={{
+              color: dashboardColors.get("grey-650"),
+              fontSize: "0.875rem",
+              lineHeight: "1.125rem",
             }}
           >
             {t("notification_types.main_scopes.note_1", { ns: "numeri" })}
@@ -170,18 +175,7 @@ const NotificationsTypes = ({ selYear }: Props) => {
             categorySignal={categories[curOption] ?? null}
             yearSignal={selYear}
           />
-          <Typography
-            sx={{
-              color: dashboardColors.get("grey-650"),
-              fontSize: "0.875rem",
-              lineHeight: "1.125rem",
-            }}
-          >
-            {t("notification_types.main_scopes.note_2", { ns: "numeri" })}
-          </Typography>
-        </Stack>
-      </KpiCard>
-    </Box>
+    </Stack>
   );
 };
 export default NotificationsTypes;

--- a/src/components/Numeri/components/SectionLayout.tsx
+++ b/src/components/Numeri/components/SectionLayout.tsx
@@ -5,10 +5,12 @@ type Props = {
   title: string;
   children: React.ReactNode;
   text?: string;
+  note?: React.ReactNode;
+  mb?: number;
 };
 
-const SectionLayout = ({ title, children, text }: Props) => (
-  <Box component="section" marginBottom={12}>
+const SectionLayout = ({ title, children, text, note, mb = 12 }: Props) => (
+  <Box component="section" marginBottom={mb}>
     <Box marginBottom={6}>
       <Typography
         component="h2"
@@ -33,6 +35,7 @@ const SectionLayout = ({ title, children, text }: Props) => (
       >
         {text}
       </Typography>
+      {note && <Box mt={1}>{note}</Box>}
     </Box>
 
     <Stack direction={{ xs: "column" }} spacing={{ xs: 2, md: 6 }}>

--- a/src/components/Numeri/components/TopAtti.tsx
+++ b/src/components/Numeri/components/TopAtti.tsx
@@ -1,11 +1,9 @@
-import { Box, Stack, Typography } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import { TopLevelSpec } from "vega-lite";
 import { useTranslation } from "../../../hook/useTranslation";
 import { toVegaLiteSpec } from "../shared/toVegaLiteSpec";
 import topAttiSpec from "../assets/data/top-atti.vl.json";
 import { dashboardColors } from "../shared/colors";
-import CardText from "./CardText";
-import KpiCard from "./KpiCard";
 import TopAttiChart from "./TopAttiChart";
 
 function translateTooltip(spec: TopLevelSpec) {
@@ -49,17 +47,7 @@ const TopAtti = ({ selYear }: Props) => {
   const { t } = useTranslation(["numeri"]);
 
   return (
-    <Box sx={{ height: "49rem" }}>
-      <KpiCard>
-        <Stack direction="column" spacing={2}>
-          <CardText>
-            {t("atti.note_1", { ns: "numeri" })}
-          </CardText>
-
-          <TopAttiChart
-            spec={translateTooltip(toVegaLiteSpec(topAttiSpec))}
-            yearSignal={selYear}
-          />
+    <Stack direction="column" spacing={2}>
           <Typography
             sx={{
               color: dashboardColors.get("grey-650"),
@@ -69,9 +57,21 @@ const TopAtti = ({ selYear }: Props) => {
           >
             {t("atti.note_2", { ns: "numeri" })}
           </Typography>
-        </Stack>
-      </KpiCard>
-    </Box>
+          <Typography
+            sx={{
+              color: dashboardColors.get("grey-650"),
+              fontSize: "0.875rem",
+              lineHeight: "1.125rem",
+            }}
+          >
+            {t("atti.note_1", { ns: "numeri" })}
+          </Typography>
+
+          <TopAttiChart
+            spec={translateTooltip(toVegaLiteSpec(topAttiSpec))}
+            yearSignal={selYear}
+          />
+    </Stack>
   );
 };
 

--- a/src/components/Numeri/components/TopCategorieEnti.tsx
+++ b/src/components/Numeri/components/TopCategorieEnti.tsx
@@ -1,0 +1,39 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { useTranslation } from "../../../hook/useTranslation";
+import { toVegaLiteSpec } from "../shared/toVegaLiteSpec";
+import topCategorieEntiSpec from "../assets/data/top-categorie-enti.vl.json";
+import { dashboardColors } from "../shared/colors";
+import KpiCard from "./KpiCard";
+import TopCategorieEntiChart from "./TopCategorieEntiChart";
+
+type Props = {
+  selYear?: number | null;
+};
+
+const TopCategorieEnti = ({ selYear }: Props) => {
+  const { t } = useTranslation(["numeri"]);
+
+  return (
+    <Box sx={{ height: "49rem" }}>
+      <KpiCard>
+        <Stack direction="column" spacing={2}>
+          <TopCategorieEntiChart
+            spec={toVegaLiteSpec(topCategorieEntiSpec)}
+            yearSignal={selYear}
+          />
+          <Typography
+            sx={{
+              color: dashboardColors.get("grey-650"),
+              fontSize: "0.875rem",
+              lineHeight: "1.125rem",
+            }}
+          >
+            {t("categorie_enti.note_1", { ns: "numeri" })}
+          </Typography>
+        </Stack>
+      </KpiCard>
+    </Box>
+  );
+};
+
+export default TopCategorieEnti;

--- a/src/components/Numeri/components/TopCategorieEntiChart.tsx
+++ b/src/components/Numeri/components/TopCategorieEntiChart.tsx
@@ -1,0 +1,52 @@
+import Box from "@mui/material/Box";
+import { useEffect, useRef, useState } from "react";
+import embed, { Result } from "vega-embed";
+import { TopLevelSpec } from "vega-lite";
+import chartConfig from "../shared/chart-config";
+import { removeGraphicsSymbolRole } from "../shared/removeGraphicsSymbolRole";
+
+type Props = {
+  spec: TopLevelSpec;
+  yearSignal?: number | null;
+};
+
+const TopCategorieEntiChart = ({ spec, yearSignal }: Props) => {
+  const [chart, setChart] = useState<Result | null>(null);
+  const chartContent = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!chartContent.current) {
+      return;
+    }
+    embed(chartContent.current, spec, chartConfig)
+      .then((result) => {
+        setChart(result);
+        setTimeout(() => removeGraphicsSymbolRole(chartContent), 100);
+      })
+      .catch(console.error);
+  }, [spec]);
+
+  useEffect(() => {
+    if (chart === null || yearSignal === undefined) {
+      return;
+    }
+    chart.view
+      .signal("year", yearSignal)
+      .resize()
+      .runAsync()
+      .then(() => {
+        setTimeout(() => removeGraphicsSymbolRole(chartContent), 100);
+      })
+      .catch(console.error);
+  }, [chart, yearSignal]);
+
+  return (
+    <Box
+      sx={{ height: "100%", width: "100%" }}
+      ref={chartContent}
+      id="chart-content-categorie-enti"
+    ></Box>
+  );
+};
+
+export default TopCategorieEntiChart;

--- a/src/components/Numeri/shared/jsonTypes.ts
+++ b/src/components/Numeri/shared/jsonTypes.ts
@@ -1,9 +1,10 @@
 export type SectionTwoData = {
   last_run: Date;
-  enti: Array<EntiPerAnno>;
+  enti_attivi: Array<EntiPerAnno>;
   geo_comuni: Array<GeoComuni>;
   top10_ambiti: Array<Ambiti>;
   top10_atti: Array<Atto>;
+  notif_enti_category: Array<CategoriaEnte>;
 };
 
 export type EntiPerAnno = {
@@ -15,7 +16,6 @@ export type EntiPerAnno = {
 export type GeoComuni = {
   year: string | null;
   regione: string;
-  num_comuni_tot: number;
   num_comuni_attivi: number;
   perc_comuni_attivi: number;
 };
@@ -30,7 +30,14 @@ export type Ambiti = {
 
 export type Atto = {
   year: string | null;
-  atto: string;
+  tipologia_atto: string;
+  num_iun: number;
+  ranking: number;
+};
+
+export type CategoriaEnte = {
+  year: string | null;
+  categoria_ente: string;
   num_iun: number;
   ranking: number;
 };

--- a/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
+++ b/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
@@ -1,6 +1,6 @@
 import type { GetStaticPaths, InferGetStaticPropsType } from "next";
 
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Link, Stack, Typography } from "@mui/material";
 import { MIAlert } from "@pagopa/mui-italia";
 import Script from "next/script";
 import { useMemo, useState } from "react";
@@ -47,6 +47,7 @@ import PieChartWrapper from "src/components/Numeri/components/PieChartWrapper";
 import { getVegaLocale } from "src/components/Numeri/shared/getVegaLocale";
 import KpiEntitiesPerc from "src/components/Numeri/components/KpiEntitiesPerc";
 import Maps from "src/components/Numeri/components/Maps";
+import TopCategorieEnti from "src/components/Numeri/components/TopCategorieEnti";
 import { dashboardColors } from "src/components/Numeri/shared/colors";
 
 type Tabs = {
@@ -391,6 +392,25 @@ const SendInNumbers = ({
           <SectionLayout
             title={t("avvisi.title")}
             text={t("avvisi.description")}
+            note={
+              <Typography
+                sx={{
+                  fontSize: "0.875rem",
+                  color: dashboardColors.get("grey-650"),
+                  lineHeight: "1.25rem",
+                }}
+              >
+                {t("avvisi.note")}
+                <Link
+                  href="https://assistenza.notifichedigitali.it/hc/it/articles/33410411666705-Cos-%C3%A8-l-avviso-di-cortesia"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{ fontWeight: 600, color: dashboardColors.get("blue-io"), textDecorationColor: dashboardColors.get("blue-io") }}
+                >
+                  {t("avvisi.note_link")}
+                </Link>
+              </Typography>
+            }
           >
             <Stack
               direction={{ xs: "column", sm: "row" }}
@@ -547,17 +567,70 @@ const SendInNumbers = ({
             </Stack>
           </SectionLayout>
           <SectionLayout
-            title={t("notification_types.title", { ns: "numeri" })}
-            text={t("notification_types.description", { ns: "numeri" })}
+            title={t("categorie_enti.title", { ns: "numeri" })}
+            text={t("categorie_enti.description", { ns: "numeri" })}
+            mb={4}
           >
-            <NotificationsTypes selYear={selYear} />
+            <TopCategorieEnti selYear={selYear} />
           </SectionLayout>
-          <SectionLayout
-            title={t("atti.title", { ns: "numeri" })}
-            text={t("atti.description", { ns: "numeri" })}
-          >
-            <TopAtti selYear={selYear} />
-          </SectionLayout>
+          <Box component="section" sx={{ marginBottom: 12 }}>
+            <KpiCard>
+              <Stack direction="column" spacing={6}>
+                <Box>
+                  <Typography
+                    component="h2"
+                    sx={{
+                      color: dashboardColors.get("primary"),
+                      fontSize: "2.375rem",
+                      fontWeight: 700,
+                      lineHeight: "3.125rem",
+                      mb: 1,
+                    }}
+                  >
+                    {t("notification_types.title", { ns: "numeri" })}
+                  </Typography>
+                  <Typography
+                    component="p"
+                    sx={{
+                      color: dashboardColors.get("primary"),
+                      fontSize: "1.125rem",
+                      fontWeight: 400,
+                      lineHeight: "1.5rem",
+                    }}
+                  >
+                    {t("notification_types.description", { ns: "numeri" })}
+                  </Typography>
+                </Box>
+                <NotificationsTypes selYear={selYear} />
+                <Box>
+                  <Typography
+                    component="h2"
+                    sx={{
+                      color: dashboardColors.get("primary"),
+                      fontSize: "2.375rem",
+                      fontWeight: 700,
+                      lineHeight: "3.125rem",
+                      mb: 1,
+                    }}
+                  >
+                    {t("atti.title", { ns: "numeri" })}
+                  </Typography>
+                  <Typography
+                    component="p"
+                    sx={{
+                      color: dashboardColors.get("primary"),
+                      fontSize: "1.125rem",
+                      fontWeight: 400,
+                      lineHeight: "1.5rem",
+                    }}
+                  >
+                    {t("atti.description", { ns: "numeri" })}
+                  </Typography>
+                </Box>
+                <TopAtti selYear={selYear} />
+              </Stack>
+            </KpiCard>
+          </Box>
         </Box>
       </Box>
     </>

--- a/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
+++ b/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
@@ -1,6 +1,7 @@
 import type { GetStaticPaths, InferGetStaticPropsType } from "next";
 
 import { Box, Stack, Typography } from "@mui/material";
+import { MIAlert } from "@pagopa/mui-italia";
 import Script from "next/script";
 import { useMemo, useState } from "react";
 import Head from "next/head";
@@ -23,6 +24,7 @@ import avvisiAppIoSpec from "../../components/Numeri/assets/data/avvisi-app-io.v
 import avvisiEmailSmsSpec from "../../components/Numeri/assets/data/avvisi-email-sms.vl.json";
 import pieChartAvvisiSpec from "../../components/Numeri/assets/data/pie-chart-avvisi.vl.json";
 import { langCodes } from "@utils/constants";
+import { isAlertVisibleWithTimezone } from "@utils/dateUtils";
 import Icons from "src/components/Numeri/components/Icons";
 import KpiCard from "src/components/Numeri/components/KpiCard";
 import KpiSignal from "src/components/Numeri/components/KpiSignal";
@@ -207,6 +209,15 @@ const SendInNumbers = ({
             </AlertWrapper>
           </Box>
         </Stack>
+        {isAlertVisibleWithTimezone() && (
+          <Box paddingTop={4}>
+            <MIAlert
+              severity="warning"
+              title={t("hero.maintenance_alert_title", { ns: "numeri" })}
+              description={t("hero.maintenance_alert", { ns: "numeri" })}
+            />
+          </Box>
+        )}
         <Box component="main" paddingTop={6}>
           <CardText sx={{ mb: 1.5 }}>
             {t("sent_notifications.filters", { ns: "numeri" })}

--- a/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
+++ b/src/pages/[lang]/send-in-numeri-283d8d30-e558-4ef6-9083-8f4ef9f8b8c5.tsx
@@ -215,8 +215,9 @@ const SendInNumbers = ({
             <MIAlert
               severity="warning"
               title={t("hero.maintenance_alert_title", { ns: "numeri" })}
-              description={t("hero.maintenance_alert", { ns: "numeri" })}
-            />
+            >
+              {t("hero.maintenance_alert", { ns: "numeri" })}
+            </MIAlert>
           </Box>
         )}
         <Box component="main" paddingTop={6}>

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -3,6 +3,7 @@ body {
   padding: 0;
   font-family: "Titillium Web", sans-serif;
   color: #17324d;
+  background-color: white;
 }
 
 .showcasePadding .MuiContainer-root {
@@ -16,4 +17,14 @@ body {
 
 .MuiOutlinedInput-root:has(#textFilter) {
   padding-right: 0;
+}
+
+.vg-tooltip td.key::after {
+  content: ":";
+}
+
+.vg-tooltip td.value {
+  display: table-cell !important;
+  vertical-align: bottom !important;
+  font-weight: 400;
 }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility functions for date operations
+ */
+
+/**
+ * Checks if the current date is within the alert display period
+ * The alert should be visible from July 22, 2026, 00:00 to July 24, 2026, 16:00
+ *
+ * @returns {boolean} True if the alert should be displayed, false otherwise
+ */
+export const isAlertVisibleWithTimezone = (): boolean => {
+  const now = new Date();
+
+  // Note: Month is 0-based in JavaScript Date constructor (July = 6)
+  const startDate = new Date(2026, 6, 22, 0, 0, 0);
+  const endDate = new Date(2026, 6, 24, 16, 0, 0);
+
+  return now >= startDate && now <= endDate;
+};

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -4,16 +4,16 @@
 
 /**
  * Checks if the current date is within the alert display period
- * The alert should be visible from July 22, 2026, 00:00 to July 24, 2026, 16:00
+ * The alert should be visible from August 14, 2026, 00:00 to August 25, 2026, 23:59
  *
  * @returns {boolean} True if the alert should be displayed, false otherwise
  */
 export const isAlertVisibleWithTimezone = (): boolean => {
   const now = new Date();
 
-  // Note: Month is 0-based in JavaScript Date constructor (July = 6)
-  const startDate = new Date(2026, 6, 22, 0, 0, 0);
-  const endDate = new Date(2026, 6, 24, 16, 0, 0);
+  // Note: Month is 0-based in JavaScript Date constructor (August = 7)
+  const startDate = new Date(2026, 7, 14, 0, 0, 0);
+  const endDate = new Date(2026, 7, 25, 23, 59, 59);
 
   return now >= startDate && now <= endDate;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,10 +1002,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@pagopa/mui-italia@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/mui-italia/-/mui-italia-2.4.1.tgz#39d0663a85d9c2d55d5312b98757e9d8da002e1a"
-  integrity sha512-IqT7d6AWzN0xtUTRAEb/u9QGOni2Bkb0BTPPMcdZW/1j8mb9DtMk1imE+pG2XZQfV0zKp0v80L1pnAjkguF4ag==
+"@pagopa/mui-italia@2.5.1-RC.0":
+  version "2.5.1-RC.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/mui-italia/-/mui-italia-2.5.1-RC.0.tgz#be917d43c3f0cd8db40186e8991ad5cdde4f1ee3"
+  integrity sha512-QgCr/4s7minf/svA72Y/8vuifXgG42ck+3iJ699VO5557SitHciGA6JD020prDzfsFP7lAxxU0jqYUMmUeJuAg==
   dependencies:
     "@fontsource/dm-mono" "^4.5.10"
     "@fontsource/titillium-web" "^4.5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,10 +1002,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@pagopa/mui-italia@2.5.1-RC.0":
-  version "2.5.1-RC.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/mui-italia/-/mui-italia-2.5.1-RC.0.tgz#be917d43c3f0cd8db40186e8991ad5cdde4f1ee3"
-  integrity sha512-QgCr/4s7minf/svA72Y/8vuifXgG42ck+3iJ699VO5557SitHciGA6JD020prDzfsFP7lAxxU0jqYUMmUeJuAg==
+"@pagopa/mui-italia@2.6.0-RC.3":
+  version "2.6.0-RC.3"
+  resolved "https://registry.yarnpkg.com/@pagopa/mui-italia/-/mui-italia-2.6.0-RC.3.tgz#5bdbbba57952e88845f4d3805ac7def337f7b00c"
+  integrity sha512-36LdMVYt80VBfZVjHOABnBd6SjB/4Z2JWr7g7oCXVrPafQWXefKYGs3JZciVc4AOtjqTY58DrLJBEzwMktIcvQ==
   dependencies:
     "@fontsource/dm-mono" "^4.5.10"
     "@fontsource/titillium-web" "^4.5.9"


### PR DESCRIPTION
## Summary
- Adds the `MIAlert` maintenance banner to the "SEND in numeri" dashboard, visible **August 14–25, 2026**
- Adds the new "Principali categorie di enti mittenti" KPI section
- Bumps `@pagopa/mui-italia` to `2.5.1-RC.0`, which fixes an `Element type is invalid` crash under Pages Router + webpack present in `^2.4.1`